### PR TITLE
fix: mobile responsive layout with hamburger nav

### DIFF
--- a/cmd/web/assets/css/styles.css
+++ b/cmd/web/assets/css/styles.css
@@ -951,3 +951,165 @@ a:hover {
 .dark .error-code {
   color: var(--green-accent);
 }
+
+/* Mobile Navigation Toggle */
+.nav-toggle-input {
+  display: none;
+}
+
+.nav-toggle-label {
+  display: none;
+  cursor: pointer;
+  font-size: 1.5rem;
+  padding: 0.5rem;
+  color: var(--text-muted);
+  min-width: 44px;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+}
+
+.dark .nav-toggle-label {
+  color: var(--text-dark);
+}
+
+.nav-links {
+  display: contents;
+}
+
+/* Mobile Responsive */
+@media (max-width: 767px) {
+  html,
+  body {
+    overflow-x: hidden;
+  }
+
+  .nav-header {
+    flex-wrap: nowrap;
+    justify-content: flex-end;
+    position: relative;
+  }
+
+  .nav-toggle-label {
+    display: flex;
+  }
+
+  .nav-links {
+    display: none;
+    flex-direction: column;
+    width: 100%;
+    padding: 0.5rem 0;
+  }
+
+  .nav-toggle-input:checked ~ .nav-links {
+    display: flex;
+  }
+
+  .nav-link {
+    padding: 0.75rem 1rem;
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+  }
+
+  .banner-title {
+    font-size: 1.5rem;
+  }
+
+  .main-content {
+    padding: 1rem 0.75rem;
+  }
+
+  .category-title,
+  .home-title {
+    font-size: 1.5rem;
+  }
+
+  .home-title {
+    font-size: 1.75rem;
+  }
+
+  .section-grid-2,
+  .section-grid-3 {
+    grid-template-columns: 1fr;
+  }
+
+  .card-container,
+  .card-container-static {
+    flex-direction: column;
+  }
+
+  .card-image {
+    width: 100%;
+    height: auto;
+    max-height: 12rem;
+    margin-right: 0;
+    margin-bottom: 0.75rem;
+  }
+
+  .card-subtitle {
+    white-space: normal;
+  }
+
+  .card-body {
+    white-space: normal;
+  }
+
+  .header-controls {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  #login-container label {
+    display: block;
+    width: auto;
+    text-align: left;
+    margin-right: 0;
+    margin-bottom: 0.25rem;
+  }
+
+  .login-input {
+    max-width: 100%;
+  }
+
+  .admin-search-form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .admin-search-input {
+    max-width: 100%;
+  }
+
+  .button {
+    min-height: 44px;
+    min-width: 44px;
+  }
+
+  .error-code {
+    font-size: 4rem;
+  }
+
+  .banner-footer {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .footer-nav {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.5rem;
+  }
+
+  .nav-footer-link {
+    margin-left: 0;
+    padding: 0.25rem 0.5rem;
+  }
+
+  .filter-select {
+    width: 100%;
+    margin-left: 0;
+    margin-top: 0.5rem;
+  }
+}

--- a/cmd/web/base.templ
+++ b/cmd/web/base.templ
@@ -35,11 +35,15 @@ templ Base(activePage string) {
 				<p class="banner-subtitle">Tim's interests</p>
 			</header>
 			<nav class="nav-header">
-				<a href="/home" class={ "nav-link", templ.KV("active", activePage == "home") }><i class="fa-solid fa-house"></i> Home</a>
-				<a href="/articles" class={ "nav-link", templ.KV("active", activePage == "articles") }><i class="fa-solid fa-newspaper"></i> Articles</a>
-				<a href="/projects" class={ "nav-link", templ.KV("active", activePage == "projects") }><i class="fa-brands fa-github"></i> Projects</a>
-				<a href="/reading-list" class={ "nav-link", templ.KV("active", activePage == "reading-list") }><i class="fa-solid fa-book"></i> Reading List</a>
-				<a href="/about" class={ "nav-link", templ.KV("active", activePage == "about") }><i class="fa-solid fa-question"></i> About</a>
+				<input type="checkbox" id="nav-toggle" class="nav-toggle-input" />
+				<label for="nav-toggle" class="nav-toggle-label"><i class="fa-solid fa-bars"></i></label>
+				<div class="nav-links">
+					<a href="/home" class={ "nav-link", templ.KV("active", activePage == "home") }><i class="fa-solid fa-house"></i> Home</a>
+					<a href="/articles" class={ "nav-link", templ.KV("active", activePage == "articles") }><i class="fa-solid fa-newspaper"></i> Articles</a>
+					<a href="/projects" class={ "nav-link", templ.KV("active", activePage == "projects") }><i class="fa-brands fa-github"></i> Projects</a>
+					<a href="/reading-list" class={ "nav-link", templ.KV("active", activePage == "reading-list") }><i class="fa-solid fa-book"></i> Reading List</a>
+					<a href="/about" class={ "nav-link", templ.KV("active", activePage == "about") }><i class="fa-solid fa-question"></i> About</a>
+				</div>
 			</nav>
 			<main id="main-content" class="main-content animate-fade-in">
 				{ children... }


### PR DESCRIPTION
## Summary
- Add CSS-only hamburger menu for mobile navigation (under 768px)
- Fix horizontal overflow, card layout, text wrapping, and grid breakpoints
- Ensure 44px minimum touch targets on interactive elements
- Stack form fields and footer elements vertically on small screens

### Changes
- **`base.templ`**: Wrap nav links in toggle container with checkbox/label hamburger
- **`styles.css`**: Add `@media (max-width: 767px)` section with mobile-specific rules

### What was fixed
| Issue | Fix |
|-------|-----|
| Nav overflows on mobile | Hamburger toggle collapses links |
| Cards break on narrow screens | Stack vertically with full-width images |
| Text clips with `white-space: nowrap` | Allow wrapping on mobile |
| Grids don't collapse | Single column below 768px |
| Login labels squeeze inputs | Stack labels above inputs |
| Touch targets too small | 44px minimum on nav links + buttons |

## Test plan
- [x] Verified on localhost at 375px width (iPhone SE)
- [x] Verified on localhost at 768px width (tablet)
- [x] All tests pass (`go test ./... -count=1`)
- [x] Zero lint issues

Closes #119