### PR TITLE
fix: bump Dockerfile Go base image to 1.26 to match go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Golang build image
-FROM golang:1.24-alpine AS build
+FROM golang:1.26-alpine AS build
 RUN apk add --no-cache alpine-sdk
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- Dockerfile was pinned to `golang:1.24-alpine` but `go.mod` requires Go 1.26
- Deploy CI failing at `go mod download`: `go.mod requires go >= 1.26 (running go 1.24.13)`
- One-line fix: `golang:1.24-alpine` → `golang:1.26-alpine`

## Test plan
- [ ] CI build passes on this PR
- [ ] Deploy workflow succeeds after merge