### PR TITLE
fix: guard GetImage against empty path; fix image-path form field name

### DIFF
--- a/cmd/web/download_test.go
+++ b/cmd/web/download_test.go
@@ -19,11 +19,13 @@ func TestDownloadDocumentHandler(t *testing.T) {
 		mdContent := "# Test\n\nbody content"
 		mdPath := filepath.Join(dir, "articles", "test.md")
 
-		if err := os.MkdirAll(filepath.Dir(mdPath), 0750); err != nil {
+		err := os.MkdirAll(filepath.Dir(mdPath), 0750)
+		if err != nil {
 			t.Fatalf("failed to create dir: %v", err)
 		}
 
-		if err := os.WriteFile(mdPath, []byte(mdContent), 0600); err != nil {
+		err = os.WriteFile(mdPath, []byte(mdContent), 0600)
+		if err != nil {
 			t.Fatalf("failed to write md file: %v", err)
 		}
 
@@ -31,6 +33,7 @@ func TestDownloadDocumentHandler(t *testing.T) {
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/download?key=articles/test.yaml", nil)
 		addAuthCookie(req)
+
 		rec := httptest.NewRecorder()
 
 		web.DownloadDocumentHandler(rec, req, s, "articles/test.yaml", a)
@@ -53,6 +56,7 @@ func TestDownloadDocumentHandler(t *testing.T) {
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/download", nil)
 		addAuthCookie(req)
+
 		rec := httptest.NewRecorder()
 
 		web.DownloadDocumentHandler(rec, req, s, "", a)

--- a/cmd/web/download_test.go
+++ b/cmd/web/download_test.go
@@ -1,0 +1,77 @@
+package web_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"timterests/cmd/web"
+	"timterests/internal/storage"
+)
+
+func TestDownloadDocumentHandler(t *testing.T) {
+	a, addAuthCookie := testAuthentication(t)
+
+	t.Run("serves paired .md file when given a .yaml key", func(t *testing.T) {
+		dir := t.TempDir()
+
+		mdContent := "# Test\n\nbody content"
+		mdPath := filepath.Join(dir, "articles", "test.md")
+
+		if err := os.MkdirAll(filepath.Dir(mdPath), 0750); err != nil {
+			t.Fatalf("failed to create dir: %v", err)
+		}
+
+		if err := os.WriteFile(mdPath, []byte(mdContent), 0600); err != nil {
+			t.Fatalf("failed to write md file: %v", err)
+		}
+
+		s := storage.Storage{UseS3: false, BaseDir: dir}
+
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/download?key=articles/test.yaml", nil)
+		addAuthCookie(req)
+		rec := httptest.NewRecorder()
+
+		web.DownloadDocumentHandler(rec, req, s, "articles/test.yaml", a)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+
+		if ct := rec.Header().Get("Content-Type"); ct != "text/markdown" {
+			t.Errorf("expected Content-Type text/markdown, got %q", ct)
+		}
+
+		if cd := rec.Header().Get("Content-Disposition"); cd == "" {
+			t.Error("expected Content-Disposition header to be set")
+		}
+	})
+
+	t.Run("returns 400 for missing key", func(t *testing.T) {
+		s := storage.Storage{UseS3: false, BaseDir: t.TempDir()}
+
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/download", nil)
+		addAuthCookie(req)
+		rec := httptest.NewRecorder()
+
+		web.DownloadDocumentHandler(rec, req, s, "", a)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected status 400, got %d", rec.Code)
+		}
+	})
+
+	t.Run("returns 401 for unauthenticated request", func(t *testing.T) {
+		s := storage.Storage{UseS3: false, BaseDir: t.TempDir()}
+
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/download?key=articles/test.yaml", nil)
+		rec := httptest.NewRecorder()
+
+		web.DownloadDocumentHandler(rec, req, s, "articles/test.yaml", a)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("expected status 401, got %d", rec.Code)
+		}
+	})
+}

--- a/cmd/web/projects.templ
+++ b/cmd/web/projects.templ
@@ -56,7 +56,7 @@ templ ProjectDisplay(dc model.DisplayContent, repository string, userIsAdmin boo
     @EditProjectButton(dc, userIsAdmin)
     @components.DownloadDocumentButton(dc.S3Key, userIsAdmin)
     <div id="project-container">
-		if repository != "Private" {
+		if repository != "" && repository != "Private" {
 			<p class="content-text"><i class="fa-brands fa-github"></i> Repository: <a href={ templ.SafeURL(repository) } class="content-text" target="_blank">{ repository }</a></p>
 		}
         @templ.Raw(dc.Body)

--- a/cmd/web/projects_test.go
+++ b/cmd/web/projects_test.go
@@ -1,12 +1,15 @@
 package web_test
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"timterests/cmd/web"
 	"timterests/internal/auth"
+	"timterests/internal/model"
 	"timterests/internal/service"
 
 	"github.com/PuerkitoBio/goquery"
@@ -254,6 +257,58 @@ func TestProjectCardConversion(t *testing.T) {
 
 		if card.ImagePath != project.Image {
 			t.Errorf("expected card image path %q, got %q", project.Image, card.ImagePath)
+		}
+	})
+}
+
+func TestProjectRepositoryRendering(t *testing.T) {
+	dc := model.DisplayContent{ID: "0", S3Key: "projects/test.yaml", Body: ""}
+
+	renderDisplay := func(t *testing.T, repository string) *goquery.Document {
+		t.Helper()
+
+		var buf bytes.Buffer
+
+		err := web.ProjectDisplay(dc, repository, false).Render(context.Background(), &buf)
+		if err != nil {
+			t.Fatalf("failed to render ProjectDisplay: %v", err)
+		}
+
+		doc, err := goquery.NewDocumentFromReader(strings.NewReader(buf.String()))
+		if err != nil {
+			t.Fatalf("failed to parse rendered HTML: %v", err)
+		}
+
+		return doc
+	}
+
+	t.Run("hides repository link when empty", func(t *testing.T) {
+		doc := renderDisplay(t, "")
+
+		if doc.Find("#project-container a").Length() > 0 {
+			t.Error("expected no repository link when repository is empty, but one was rendered")
+		}
+	})
+
+	t.Run("hides repository link when Private", func(t *testing.T) {
+		doc := renderDisplay(t, "Private")
+
+		if doc.Find("#project-container a").Length() > 0 {
+			t.Error("expected no repository link when repository is 'Private', but one was rendered")
+		}
+	})
+
+	t.Run("renders repository link when URL is set", func(t *testing.T) {
+		repo := "https://github.com/test/repo"
+		doc := renderDisplay(t, repo)
+
+		link := doc.Find("#project-container a")
+		if link.Length() == 0 {
+			t.Error("expected repository link to be rendered, but it was not")
+		}
+
+		if href, _ := link.Attr("href"); href != repo {
+			t.Errorf("expected href %q, got %q", repo, href)
 		}
 	})
 }

--- a/cmd/web/writer.go
+++ b/cmd/web/writer.go
@@ -278,12 +278,12 @@ func loadRawDoc[T any, PT interface {
 		body = ""
 	}
 
-	return model.Content[T]{Doc: doc, Body: stripDocumentHeaders(body)}, nil
+	return model.Content[T]{Doc: doc, Body: StripDocumentHeaders(body)}, nil
 }
 
-// stripDocumentHeaders removes the "# Title\n## Subtitle\n\n" prefix that
+// StripDocumentHeaders removes the "# Title\n## Subtitle\n\n" prefix that
 // WriteMarkdownDocument prepends, so the writer textarea shows only body content.
-func stripDocumentHeaders(raw string) string {
+func StripDocumentHeaders(raw string) string {
 	lines := strings.SplitN(raw, "\n", 4)
 	if len(lines) >= 2 &&
 		strings.HasPrefix(lines[0], "# ") &&

--- a/cmd/web/writer.templ
+++ b/cmd/web/writer.templ
@@ -134,8 +134,8 @@ templ LetterFormContent(letter *model.Letter) {
 
 templ ProjectFormContent(project *model.Project) {
     <div class="form-field">
-        <label class="form-label" for="image-path">Image Path:</label>
-        <input class="form-input" type="text" id="image-path" name="image-path" placeholder="Path to image" value={project.Image} required>
+        <label class="form-label" for="imagePath">Image Path:</label>
+        <input class="form-input" type="text" id="imagePath" name="imagePath" placeholder="Path to image" value={project.Image} required>
     </div>
     <div class="form-field">
         <label class="form-label" for="repository">Repository:</label>

--- a/cmd/web/writer.templ
+++ b/cmd/web/writer.templ
@@ -135,7 +135,7 @@ templ LetterFormContent(letter *model.Letter) {
 templ ProjectFormContent(project *model.Project) {
     <div class="form-field">
         <label class="form-label" for="imagePath">Image Path:</label>
-        <input class="form-input" type="text" id="imagePath" name="imagePath" placeholder="Path to image" value={project.Image} required>
+        <input class="form-input" type="text" id="imagePath" name="imagePath" placeholder="Path to image" value={project.Image}>
     </div>
     <div class="form-field">
         <label class="form-label" for="repository">Repository:</label>

--- a/cmd/web/writer_strip_test.go
+++ b/cmd/web/writer_strip_test.go
@@ -1,6 +1,9 @@
-package web
+package web_test
 
-import "testing"
+import (
+	"testing"
+	"timterests/cmd/web"
+)
 
 func TestStripDocumentHeaders(t *testing.T) {
 	tests := []struct {
@@ -47,9 +50,9 @@ func TestStripDocumentHeaders(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := stripDocumentHeaders(tc.input)
+			got := web.StripDocumentHeaders(tc.input)
 			if got != tc.expected {
-				t.Errorf("stripDocumentHeaders(%q) = %q, want %q", tc.input, got, tc.expected)
+				t.Errorf("StripDocumentHeaders(%q) = %q, want %q", tc.input, got, tc.expected)
 			}
 		})
 	}

--- a/cmd/web/writer_strip_test.go
+++ b/cmd/web/writer_strip_test.go
@@ -1,0 +1,56 @@
+package web
+
+import "testing"
+
+func TestStripDocumentHeaders(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "strips title and subtitle leaving body",
+			input:    "# My Title\n## My Subtitle\n\nbody content here",
+			expected: "body content here",
+		},
+		{
+			name:     "strips headers from multiline body",
+			input:    "# Title\n## Subtitle\n\nline one\nline two\nline three",
+			expected: "line one\nline two\nline three",
+		},
+		{
+			name:     "returns empty string when body is absent",
+			input:    "# Title\n## Subtitle\n\n",
+			expected: "",
+		},
+		{
+			name:     "returns input unchanged when no h1 prefix",
+			input:    "just some body text",
+			expected: "just some body text",
+		},
+		{
+			name:     "returns input unchanged when only h1 present",
+			input:    "# Title\nbody without subtitle",
+			expected: "# Title\nbody without subtitle",
+		},
+		{
+			name:     "returns input unchanged when h1 but no h2",
+			input:    "# Title\nsome content\n## not-a-subtitle",
+			expected: "# Title\nsome content\n## not-a-subtitle",
+		},
+		{
+			name:     "returns input unchanged when empty",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stripDocumentHeaders(tc.input)
+			if got != tc.expected {
+				t.Errorf("stripDocumentHeaders(%q) = %q, want %q", tc.input, got, tc.expected)
+			}
+		})
+	}
+}

--- a/internal/service/project_service.go
+++ b/internal/service/project_service.go
@@ -73,14 +73,16 @@ func GetProject(ctx context.Context, s storage.Storage, key string, id int) (*mo
 		return nil, err
 	}
 
-	imagePath, err := s.GetImage(ctx, project.Image)
-	if err != nil {
-		log.Printf("Failed to download image: %v", err)
+	if project.Image != "" {
+		imagePath, err := s.GetImage(ctx, project.Image)
+		if err != nil {
+			log.Printf("Failed to download image: %v", err)
 
-		return nil, fmt.Errorf("failed to resolve image %q: %w", project.Image, err)
+			return nil, fmt.Errorf("failed to resolve image %q: %w", project.Image, err)
+		}
+
+		project.Image = imagePath
 	}
-
-	project.Image = imagePath
 
 	return project, nil
 }

--- a/internal/service/project_service_test.go
+++ b/internal/service/project_service_test.go
@@ -87,6 +87,21 @@ func TestGetProject(t *testing.T) {
 			t.Error("expected error for non-existent file, got nil")
 		}
 	})
+
+	t.Run("succeeds when project has no image path", func(t *testing.T) {
+		project, err := service.GetProject(ctx, *s, "projects/no-image-project.yaml", 0)
+		if err != nil {
+			t.Fatalf("expected no error for project without image, got: %v", err)
+		}
+
+		if project.Image != "" {
+			t.Errorf("expected empty image, got %q", project.Image)
+		}
+
+		if project.Title != "No Image Project" {
+			t.Errorf("expected title 'No Image Project', got %q", project.Title)
+		}
+	})
 }
 
 func TestGetFeaturedProject(t *testing.T) {

--- a/internal/service/reading_list_service.go
+++ b/internal/service/reading_list_service.go
@@ -70,14 +70,16 @@ func GetBook(ctx context.Context, s storage.Storage, key string, id int) (*model
 		return nil, err
 	}
 
-	imagePath, err := s.GetImage(ctx, book.Image)
-	if err != nil {
-		log.Printf("Failed to download image: %v", err)
+	if book.Image != "" {
+		imagePath, err := s.GetImage(ctx, book.Image)
+		if err != nil {
+			log.Printf("Failed to download image: %v", err)
 
-		return nil, fmt.Errorf("failed to resolve image %q: %w", book.Image, err)
+			return nil, fmt.Errorf("failed to resolve image %q: %w", book.Image, err)
+		}
+
+		book.Image = imagePath
 	}
-
-	book.Image = imagePath
 
 	return book, nil
 }

--- a/internal/service/reading_list_service_test.go
+++ b/internal/service/reading_list_service_test.go
@@ -95,4 +95,19 @@ func TestGetBook(t *testing.T) {
 			t.Error("expected error for non-existent file, got nil")
 		}
 	})
+
+	t.Run("succeeds when book has no image path", func(t *testing.T) {
+		book, err := service.GetBook(ctx, *s, "reading-list/no-image-book.yaml", 0)
+		if err != nil {
+			t.Fatalf("expected no error for book without image, got: %v", err)
+		}
+
+		if book.Image != "" {
+			t.Errorf("expected empty image, got %q", book.Image)
+		}
+
+		if book.Title != "No Image Book" {
+			t.Errorf("expected title 'No Image Book', got %q", book.Title)
+		}
+	})
 }

--- a/storage/testdata/projects/no-image-project.md
+++ b/storage/testdata/projects/no-image-project.md
@@ -1,0 +1,5 @@
+# No Image Project
+
+## A project without an image path.
+
+This project has no image to verify that the service handles empty image paths gracefully.

--- a/storage/testdata/projects/no-image-project.yaml
+++ b/storage/testdata/projects/no-image-project.yaml
@@ -1,0 +1,6 @@
+title: No Image Project
+subtitle: A project without an image path.
+preview: Testing that projects without images load correctly.
+repository: https://github.com/test/no-image-repo
+tags:
+  - Golang

--- a/storage/testdata/reading-list/no-image-book.md
+++ b/storage/testdata/reading-list/no-image-book.md
@@ -1,0 +1,5 @@
+# No Image Book
+
+## A book without a cover image.
+
+This book has no cover image to verify that the service handles empty image paths gracefully.

--- a/storage/testdata/reading-list/no-image-book.yaml
+++ b/storage/testdata/reading-list/no-image-book.yaml
@@ -1,0 +1,10 @@
+title: No Image Book
+subtitle: A book without a cover image.
+preview: Testing that books without images load correctly.
+author: Test Author
+published: "2024"
+isbn: ""
+website: ""
+status: interested
+tags:
+  - Testing


### PR DESCRIPTION
## Summary
Two bugs causing "Failed to fetch projects":

- **Form field name mismatch**: `writer.templ` sent `name="image-path"` but `model.Project` and `model.ReadingList` both use `yaml:"imagePath"`. When a project/book was created via the writer, the YAML stored `image-path:` as the key, which didn't decode into the struct — leaving `Image` empty.
- **`GetImage` crash on empty string**: `LocalPath(s.BaseDir, "")` returns an error because `filepath.IsLocal("")` is false. Both `GetProject` and `GetBook` called `GetImage` unconditionally, so any document with an empty image crashed the entire list.

## Fixes
- `writer.templ`: renamed form field `image-path` → `imagePath` to match the YAML tag
- `project_service.go`: skip `GetImage` when `Image` is empty
- `reading_list_service.go`: same guard for books

## Test plan
- [ ] CI passes
- [ ] Projects and reading list pages load without error after deploy
- [ ] Writer form correctly stores image path for new projects/books