### PR TITLE
feat: strip markdown/YAML from AI suggestions and fix suggestion overflow

### DIFF
--- a/cmd/web/assets/css/styles.css
+++ b/cmd/web/assets/css/styles.css
@@ -654,6 +654,7 @@ a:hover {
 .form-textarea {
   height: 16rem;
   resize: vertical;
+  overflow-y: auto;
 }
 
 .login-input {

--- a/cmd/web/writer.templ
+++ b/cmd/web/writer.templ
@@ -159,7 +159,7 @@ templ OpenAISuggestion() {
         <span id="ai-loading" class="htmx-indicator">Loading...</span>
     </div>
     <div class="form-field" id="suggestion-container" style="display: none;">
-        <span class="form-textarea" id="suggestion"></span>
+        <div class="form-textarea" id="suggestion"></div>
     </div>
 }
 

--- a/internal/ai/suggestion.go
+++ b/internal/ai/suggestion.go
@@ -59,7 +59,67 @@ func GenerateSuggestion(ctx context.Context, prompt, systemInstruction string) (
 		return "", errors.New("no choices returned from OpenAI API")
 	}
 
-	return chatCompletion.Choices[0].Message.Content, nil
+	return CleanSuggestion(chatCompletion.Choices[0].Message.Content), nil
+}
+
+// CleanSuggestion strips markdown and YAML formatting from AI-generated text
+// so it renders as plain prose in the suggestion display.
+func CleanSuggestion(text string) string {
+	lines := strings.Split(text, "\n")
+	out := make([]string, 0, len(lines))
+
+	inFrontmatter := false
+	inCodeBlock := false
+	frontmatterDone := false
+
+	for i, line := range lines {
+		// Strip YAML frontmatter (--- ... ---) at the top of the document.
+		if !frontmatterDone && i == 0 && strings.TrimSpace(line) == "---" {
+			inFrontmatter = true
+
+			continue
+		}
+
+		if inFrontmatter {
+			if strings.TrimSpace(line) == "---" {
+				inFrontmatter = false
+				frontmatterDone = true
+			}
+
+			continue
+		}
+
+		// Remove fenced code block delimiters; keep the content as plain text.
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			inCodeBlock = !inCodeBlock
+
+			continue
+		}
+
+		if inCodeBlock {
+			out = append(out, line)
+
+			continue
+		}
+
+		// Strip ATX headings (# Heading).
+		stripped := strings.TrimLeft(line, "#")
+		if len(stripped) < len(line) {
+			line = strings.TrimSpace(stripped)
+		}
+
+		// Strip bold/italic markers.
+		line = strings.ReplaceAll(line, "**", "")
+		line = strings.ReplaceAll(line, "__", "")
+		line = strings.ReplaceAll(line, "*", "")
+
+		// Strip inline backticks.
+		line = strings.ReplaceAll(line, "`", "")
+
+		out = append(out, line)
+	}
+
+	return strings.TrimSpace(strings.Join(out, "\n"))
 }
 
 // GetInstruction reads and returns the content of a prompt instruction file.

--- a/internal/ai/suggestion_test.go
+++ b/internal/ai/suggestion_test.go
@@ -9,6 +9,73 @@ import (
 	"timterests/internal/ai"
 )
 
+func TestCleanSuggestion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "plain text passthrough",
+			input: "This is a plain sentence.",
+			want:  "This is a plain sentence.",
+		},
+		{
+			name:  "strips YAML frontmatter",
+			input: "---\ntitle: Test\n---\nActual content here.",
+			want:  "Actual content here.",
+		},
+		{
+			name:  "strips ATX headings",
+			input: "# Big Heading\n## Sub\nBody text.",
+			want:  "Big Heading\nSub\nBody text.",
+		},
+		{
+			name:  "strips bold and italic markers",
+			input: "This is **bold** and *italic* and __also bold__.",
+			want:  "This is bold and italic and also bold.",
+		},
+		{
+			name:  "strips inline backticks",
+			input: "Call `fmt.Println` to print.",
+			want:  "Call fmt.Println to print.",
+		},
+		{
+			name:  "removes code fence delimiters, keeps content",
+			input: "Before.\n```go\nfmt.Println(\"hi\")\n```\nAfter.",
+			want:  "Before.\nfmt.Println(\"hi\")\nAfter.",
+		},
+		{
+			name:  "frontmatter only at document start",
+			input: "Some text.\n---\nnot: frontmatter\n---\nMore text.",
+			want:  "Some text.\n---\nnot: frontmatter\n---\nMore text.",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "trims surrounding whitespace",
+			input: "\n\nHello world.\n\n",
+			want:  "Hello world.",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ai.CleanSuggestion(tc.input)
+			if got != tc.want {
+				t.Fatalf("CleanSuggestion(%q)\ngot:  %q\nwant: %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
 // Not parallel: changes working directory.
 func TestLoadAPIKey(t *testing.T) {
 	t.Run("load API key from .env file", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds `CleanSuggestion` in `internal/ai/suggestion.go` that strips YAML frontmatter, fenced code block delimiters (content preserved as plain text), ATX headings (`#`), bold/italic markers (`**`, `*`, `__`), and inline backticks from raw OpenAI responses before they reach the UI
- Wires `CleanSuggestion` into `GenerateSuggestion` so all callers get clean output automatically
- Adds `overflow-y: auto` to `.form-textarea` and changes suggestion display from `span` to `div` (block element) so height and overflow take effect
- Adds unit tests for `CleanSuggestion` covering frontmatter, headings, bold/italic, backticks, code fences, and edge cases

## Test plan
- [ ] Trigger an AI suggestion in the writer and verify plain prose renders without markdown symbols
- [ ] Submit a body that produces a long suggestion and verify the suggestion box scrolls