### PR TITLE
feat: implement global error handler with severity classification

### DIFF
--- a/cmd/web/about.go
+++ b/cmd/web/about.go
@@ -1,51 +1,48 @@
 package web
 
 import (
-	"log"
 	"net/http"
+
+	apperrors "timterests/internal/errors"
 	"timterests/internal/storage"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
-// About represents About page content.
 type About struct {
 	Title    string `yaml:"title"`
 	Subtitle string `yaml:"subtitle"`
 	Body     string `yaml:"body"`
 }
 
-// AboutHandler handles requests to the About page and serves its content.
 func AboutHandler(w http.ResponseWriter, r *http.Request, s storage.Storage) {
 	var about About
 
-	// Get all articles from the storage
 	prefix := "about/"
 
 	aboutFile, err := s.ListObjects(r.Context(), prefix)
 	if err != nil {
-		http.Error(w, "Failed to fetch about info", http.StatusInternalServerError)
+		HandleError(w, r, apperrors.StorageFailed(err), "AboutHandler", "listObjects")
 
 		return
 	}
 
 	if len(aboutFile) == 0 {
-		http.Error(w, "Not Found", http.StatusNotFound)
+		HandleError(w, r, apperrors.NotFound(nil), "AboutHandler", "findAbout")
 
 		return
 	}
 
 	key := aws.ToString(aboutFile[0].Key)
 	if key == "" {
-		http.Error(w, "Not Found", http.StatusNotFound)
+		HandleError(w, r, apperrors.NotFound(nil), "AboutHandler", "getKey")
 
 		return
 	}
 
 	err = s.GetPreparedFile(r.Context(), key, &about)
 	if err != nil {
-		http.Error(w, "Failed to prepare about info", http.StatusInternalServerError)
-		log.Printf("Error fetching about info: %v", err)
+		HandleError(w, r, apperrors.StorageFailed(err), "AboutHandler", "getPreparedFile")
 
 		return
 	}
@@ -54,7 +51,6 @@ func AboutHandler(w http.ResponseWriter, r *http.Request, s storage.Storage) {
 
 	err = renderHTML(w, r, http.StatusOK, component)
 	if err != nil {
-		log.Printf("AboutHandler: failed to render: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		HandleError(w, r, apperrors.RenderFailed(err), "AboutHandler", "render")
 	}
 }

--- a/cmd/web/admin.go
+++ b/cmd/web/admin.go
@@ -1,14 +1,15 @@
 package web
 
 import (
-	"log"
 	"net/http"
+
+	apperrors "timterests/internal/errors"
+
 	"timterests/internal/auth"
 
 	"github.com/a-h/templ"
 )
 
-// AdminPageHandler handles requests to the admin page for authenticated users.
 func AdminPageHandler(w http.ResponseWriter, r *http.Request, a *auth.Auth) {
 	var component templ.Component
 
@@ -22,7 +23,6 @@ func AdminPageHandler(w http.ResponseWriter, r *http.Request, a *auth.Auth) {
 
 	err := renderHTML(w, r, http.StatusOK, component)
 	if err != nil {
-		log.Printf("AdminPageHandler: failed to render: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		HandleError(w, r, apperrors.RenderFailed(err), "AdminPageHandler", "render")
 	}
 }

--- a/cmd/web/admin_documents.go
+++ b/cmd/web/admin_documents.go
@@ -3,7 +3,6 @@ package web
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -16,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 
 	"timterests/internal/auth"
+	apperrors "timterests/internal/errors"
 	"timterests/internal/storage"
 )
 
@@ -71,8 +71,7 @@ func AdminDocumentsPageHandler(w http.ResponseWriter, r *http.Request, s storage
 
 	docs, err := ListAllDocuments(r.Context(), s)
 	if err != nil {
-		http.Error(w, "Failed to list documents", http.StatusInternalServerError)
-		log.Printf("Error listing documents: %v", err)
+		HandleError(w, r, apperrors.StorageFailed(err), "AdminDocumentsPageHandler", "listDocuments")
 
 		return
 	}
@@ -111,8 +110,7 @@ func AdminDocumentsPageHandler(w http.ResponseWriter, r *http.Request, s storage
 
 	err = renderHTML(w, r, http.StatusOK, component)
 	if err != nil {
-		log.Printf("AdminDocumentsPageHandler: failed to render: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		HandleError(w, r, apperrors.RenderFailed(err), "AdminDocumentsPageHandler", "render")
 	}
 }
 

--- a/cmd/web/articles.go
+++ b/cmd/web/articles.go
@@ -1,9 +1,11 @@
 package web
 
 import (
-	"log"
 	"net/http"
 	"reflect"
+
+	apperrors "timterests/internal/errors"
+
 	"timterests/internal/auth"
 	"timterests/internal/model"
 	"timterests/internal/service"
@@ -12,8 +14,6 @@ import (
 	"github.com/a-h/templ"
 )
 
-// ArticlesPageHandler handles requests to the articles page,
-// ensuring authentication and rendering the appropriate content.
 func ArticlesPageHandler(w http.ResponseWriter, r *http.Request, s storage.Storage, currentTag, design string) {
 	var (
 		component templ.Component
@@ -22,8 +22,7 @@ func ArticlesPageHandler(w http.ResponseWriter, r *http.Request, s storage.Stora
 
 	articles, err := service.ListArticles(r.Context(), s, currentTag)
 	if err != nil {
-		log.Printf("ArticlesPageHandler: failed to fetch articles: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		HandleError(w, r, apperrors.StorageFailed(err), "ArticlesPageHandler", "listArticles")
 
 		return
 	}
@@ -41,16 +40,14 @@ func ArticlesPageHandler(w http.ResponseWriter, r *http.Request, s storage.Stora
 
 	err = renderHTML(w, r, http.StatusOK, component)
 	if err != nil {
-		log.Printf("ArticlesPageHandler: failed to render: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		HandleError(w, r, apperrors.RenderFailed(err), "ArticlesPageHandler", "render")
 	}
 }
 
-// GetArticleHandler retrieves and renders a specific article by its ID.
 func GetArticleHandler(w http.ResponseWriter, r *http.Request, s storage.Storage, articleID string, a *auth.Auth) {
 	articles, err := service.ListArticles(r.Context(), s, "all")
 	if err != nil {
-		http.Error(w, "Failed to fetch articles", http.StatusInternalServerError)
+		HandleError(w, r, apperrors.StorageFailed(err), "GetArticleHandler", "listArticles")
 
 		return
 	}
@@ -59,8 +56,7 @@ func GetArticleHandler(w http.ResponseWriter, r *http.Request, s storage.Storage
 		if article.ID == articleID {
 			body, err := s.GetDocumentBody(r.Context(), article.S3Key)
 			if err != nil {
-				log.Printf("GetArticleHandler: failed to load body for %s: %v", article.S3Key, err)
-				http.Error(w, "Not Found", http.StatusNotFound)
+				HandleError(w, r, apperrors.NotFound(err), "GetArticleHandler", "getBody")
 
 				return
 			}
@@ -83,8 +79,7 @@ func GetArticleHandler(w http.ResponseWriter, r *http.Request, s storage.Storage
 
 			err = renderHTML(w, r, http.StatusOK, component)
 			if err != nil {
-				log.Printf("GetArticleHandler: failed to render: %v", err)
-				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				HandleError(w, r, apperrors.RenderFailed(err), "GetArticleHandler", "render")
 
 				return
 			}
@@ -93,10 +88,9 @@ func GetArticleHandler(w http.ResponseWriter, r *http.Request, s storage.Storage
 		}
 	}
 
-	http.Error(w, "Not Found", http.StatusNotFound)
+	HandleError(w, r, apperrors.NotFound(nil), "GetArticleHandler", "findArticle")
 }
 
-// FormatDateForFilename converts a date string to a filename-safe format.
 func FormatDateForFilename(dateStr string) string {
 	return service.FormatArticleDateForFilename(dateStr)
 }

--- a/cmd/web/assets/css/styles.css
+++ b/cmd/web/assets/css/styles.css
@@ -921,3 +921,33 @@ a:hover {
 .fa-brands {
   margin-right: 0.25rem;
 }
+
+/* Error Page */
+.error-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 4rem 1rem;
+  min-height: 40vh;
+}
+
+.error-code {
+  font-size: 6rem;
+  font-weight: 800;
+  color: var(--green);
+  margin: 0;
+  line-height: 1;
+}
+
+.error-message {
+  font-size: 1.25rem;
+  color: var(--text-muted);
+  margin: 1rem 0 2rem;
+  max-width: 28rem;
+}
+
+.dark .error-code {
+  color: var(--green-accent);
+}

--- a/cmd/web/download.go
+++ b/cmd/web/download.go
@@ -1,50 +1,49 @@
 package web
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+
 	"timterests/internal/auth"
+	apperrors "timterests/internal/errors"
 	"timterests/internal/storage"
 )
 
-// DownloadDocumentHandler handles document download requests for authenticated users.
 func DownloadDocumentHandler(w http.ResponseWriter, r *http.Request, s storage.Storage, key string, a *auth.Auth) {
-	// Only admins can download documents
 	if !a.IsAuthenticated(r) {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		HandleError(w, r, apperrors.Unauthorized(nil), "DownloadDocumentHandler", "auth")
 
 		return
 	}
 
 	if key == "" {
-		http.Error(w, "Missing document key", http.StatusBadRequest)
+		HandleError(w, r,
+			apperrors.BadRequest(errors.New("missing document key")),
+			"DownloadDocumentHandler", "validateKey")
 
 		return
 	}
 
-	// Document listings use .yaml keys; serve the paired .md body file instead.
 	if base, ok := strings.CutSuffix(key, ".yaml"); ok {
 		key = base + ".md"
 	}
 
-	// Ensure the key is within the storage directory (prevents path traversal)
 	localPath, err := storage.LocalPath(s.BaseDir, key)
 	if err != nil {
-		http.Error(w, "Invalid document key", http.StatusBadRequest)
+		HandleError(w, r, apperrors.BadRequest(err), "DownloadDocumentHandler", "localPath")
 
 		return
 	}
 
-	// Download from S3 if needed
 	if s.UseS3 {
 		err := s.DownloadS3File(r.Context(), key)
 		if err != nil {
-			log.Printf("DownloadDocumentHandler: failed to download from S3: %v", err)
-			http.Error(w, "Failed to retrieve document", http.StatusInternalServerError)
+			HandleError(w, r, apperrors.StorageFailed(err), "DownloadDocumentHandler", "downloadS3")
 
 			return
 		}
@@ -52,26 +51,22 @@ func DownloadDocumentHandler(w http.ResponseWriter, r *http.Request, s storage.S
 
 	fileName := filepath.Base(key)
 
-	// Set headers to force download
 	w.Header().Set("Content-Disposition", "attachment; filename=\""+fileName+"\"")
 	w.Header().Set("Content-Type", "text/markdown")
 
 	http.ServeFile(w, r, localPath)
 }
 
-// DownloadNewDocumentHandler handles requests to download a new document based on form data.
-// It writes only the Markdown body (with title/subtitle headers) to a temporary file and serves it.
 func DownloadNewDocumentHandler(w http.ResponseWriter, r *http.Request, a *auth.Auth) {
-	// Only admins can download documents
 	if !a.IsAuthenticated(r) {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		HandleError(w, r, apperrors.Unauthorized(nil), "DownloadNewDocumentHandler", "auth")
 
 		return
 	}
 
 	err := r.ParseForm()
 	if err != nil {
-		http.Error(w, "Failed to parse form", http.StatusBadRequest)
+		HandleError(w, r, apperrors.ParseFormFailed(err), "DownloadNewDocumentHandler", "parseForm")
 
 		return
 	}
@@ -81,7 +76,9 @@ func DownloadNewDocumentHandler(w http.ResponseWriter, r *http.Request, a *auth.
 	body := r.FormValue("body")
 
 	if title == "" {
-		http.Error(w, "Missing or invalid title field", http.StatusBadRequest)
+		HandleError(w, r,
+			apperrors.BadRequest(errors.New("missing or invalid title field")),
+			"DownloadNewDocumentHandler", "validateTitle")
 
 		return
 	}
@@ -90,13 +87,11 @@ func DownloadNewDocumentHandler(w http.ResponseWriter, r *http.Request, a *auth.
 
 	f, err := os.CreateTemp("", "download-*.md")
 	if err != nil {
-		http.Error(w, "Failed to create file", http.StatusInternalServerError)
-		log.Printf("DownloadNewDocumentHandler: failed to create temp file: %v", err)
+		HandleError(w, r, apperrors.InternalServerError(err), "DownloadNewDocumentHandler", "createTemp")
 
 		return
 	}
 
-	// Cleanup temporary file after serving
 	defer func() {
 		removeErr := os.Remove(f.Name())
 		if removeErr != nil {
@@ -112,8 +107,7 @@ func DownloadNewDocumentHandler(w http.ResponseWriter, r *http.Request, a *auth.
 	}
 
 	if err != nil {
-		http.Error(w, "Failed to write file", http.StatusInternalServerError)
-		log.Printf("DownloadNewDocumentHandler: failed to write temp file: %v", err)
+		HandleError(w, r, apperrors.InternalServerError(err), "DownloadNewDocumentHandler", "writeTemp")
 
 		return
 	}

--- a/cmd/web/error.templ
+++ b/cmd/web/error.templ
@@ -1,0 +1,17 @@
+package web
+
+import "strconv"
+
+templ ErrorPage(statusCode int, message string) {
+    @Base("") {
+        @ErrorDisplay(statusCode, message)
+    }
+}
+
+templ ErrorDisplay(statusCode int, message string) {
+    <div class="error-container">
+        <h1 class="error-code">{ strconv.Itoa(statusCode) }</h1>
+        <p class="error-message">{ message }</p>
+        <a href="/" class="button">Back to Home</a>
+    </div>
+}

--- a/cmd/web/error_handler.go
+++ b/cmd/web/error_handler.go
@@ -1,0 +1,23 @@
+package web
+
+import (
+	"net/http"
+
+	apperrors "timterests/internal/errors"
+)
+
+// HandleError logs the error with structured formatting and renders an HTML error page.
+// It classifies any error into an AppError, enriches it with handler context, logs it,
+// and renders the appropriate error page for the status code.
+func HandleError(w http.ResponseWriter, r *http.Request, err error, handler, action string) {
+	appErr := apperrors.Classify(err)
+	appErr = appErr.WithHandler(handler, action)
+	apperrors.LogError(appErr)
+
+	component := ErrorPage(appErr.HTTPStatus, appErr.Message)
+
+	renderErr := renderHTML(w, r, appErr.HTTPStatus, component)
+	if renderErr != nil {
+		http.Error(w, appErr.Message, appErr.HTTPStatus)
+	}
+}

--- a/cmd/web/home.go
+++ b/cmd/web/home.go
@@ -1,26 +1,24 @@
 package web
 
 import (
-	"log"
 	"net/http"
+
+	apperrors "timterests/internal/errors"
 	"timterests/internal/service"
 	"timterests/internal/storage"
 )
 
-// HomeHandler handles requests to the home page.
 func HomeHandler(w http.ResponseWriter, r *http.Request, s storage.Storage) {
 	latestArticle, err := service.GetLatestArticle(r.Context(), s)
 	if err != nil {
-		http.Error(w, "Failed to fetch latest article", http.StatusInternalServerError)
-		log.Printf("Error fetching latest article: %v", err)
+		HandleError(w, r, apperrors.StorageFailed(err), "HomeHandler", "getLatestArticle")
 
 		return
 	}
 
 	featuredProject, err := service.GetFeaturedProject(r.Context(), s, "Timterests")
 	if err != nil {
-		http.Error(w, "Failed to fetch featured project", http.StatusInternalServerError)
-		log.Printf("Error fetching featured project: %v", err)
+		HandleError(w, r, apperrors.StorageFailed(err), "HomeHandler", "getFeaturedProject")
 
 		return
 	}
@@ -29,7 +27,6 @@ func HomeHandler(w http.ResponseWriter, r *http.Request, s storage.Storage) {
 
 	err = renderHTML(w, r, http.StatusOK, component)
 	if err != nil {
-		log.Printf("HomeHandler: failed to render: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		HandleError(w, r, apperrors.RenderFailed(err), "HomeHandler", "render")
 	}
 }

--- a/cmd/web/letters.go
+++ b/cmd/web/letters.go
@@ -1,9 +1,11 @@
 package web
 
 import (
-	"log"
 	"net/http"
 	"reflect"
+
+	apperrors "timterests/internal/errors"
+
 	"timterests/internal/auth"
 	"timterests/internal/model"
 	"timterests/internal/service"
@@ -12,8 +14,6 @@ import (
 	"github.com/a-h/templ"
 )
 
-// LettersPageHandler handles requests to the letters page,
-// ensuring authentication and rendering the appropriate content.
 func LettersPageHandler(
 	w http.ResponseWriter,
 	r *http.Request,
@@ -25,7 +25,6 @@ func LettersPageHandler(
 		tags      []string
 	)
 
-	// Check if user is authenticated
 	if !a.IsAuthenticated(r) {
 		http.Redirect(w, r, "/login", http.StatusSeeOther)
 
@@ -34,8 +33,7 @@ func LettersPageHandler(
 
 	letters, err := service.ListLetters(r.Context(), s, currentTag)
 	if err != nil {
-		log.Printf("LettersPageHandler: failed to fetch letters: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		HandleError(w, r, apperrors.StorageFailed(err), "LettersPageHandler", "listLetters")
 
 		return
 	}
@@ -53,17 +51,13 @@ func LettersPageHandler(
 
 	err = renderHTML(w, r, http.StatusOK, component)
 	if err != nil {
-		log.Printf("LettersPageHandler: failed to render: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		HandleError(w, r, apperrors.RenderFailed(err), "LettersPageHandler", "render")
 	}
 }
 
-// GetLetterHandler retrieves a specific letter by its ID and renders it.
 func GetLetterHandler(w http.ResponseWriter, r *http.Request, s storage.Storage, letterID string, a *auth.Auth) {
-	// Check if user is authenticated
 	authenticated := a.IsAuthenticated(r)
 	if !authenticated {
-		log.Printf("User not authenticated, redirecting to login")
 		http.Redirect(w, r, "/login", http.StatusSeeOther)
 
 		return
@@ -71,7 +65,7 @@ func GetLetterHandler(w http.ResponseWriter, r *http.Request, s storage.Storage,
 
 	letters, err := service.ListLetters(r.Context(), s, "all")
 	if err != nil {
-		http.Error(w, "Failed to fetch letters", http.StatusInternalServerError)
+		HandleError(w, r, apperrors.StorageFailed(err), "GetLetterHandler", "listLetters")
 
 		return
 	}
@@ -82,8 +76,7 @@ func GetLetterHandler(w http.ResponseWriter, r *http.Request, s storage.Storage,
 		if letter.ID == letterID {
 			body, err := s.GetDocumentBody(r.Context(), letter.S3Key)
 			if err != nil {
-				log.Printf("GetLetterHandler: failed to load body for %s: %v", letter.S3Key, err)
-				http.Error(w, "Not Found", http.StatusNotFound)
+				HandleError(w, r, apperrors.NotFound(err), "GetLetterHandler", "getBody")
 
 				return
 			}
@@ -102,8 +95,7 @@ func GetLetterHandler(w http.ResponseWriter, r *http.Request, s storage.Storage,
 
 			err = renderHTML(w, r, http.StatusOK, component)
 			if err != nil {
-				log.Printf("GetLetterHandler: failed to render: %v", err)
-				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				HandleError(w, r, apperrors.RenderFailed(err), "GetLetterHandler", "render")
 
 				return
 			}
@@ -112,5 +104,5 @@ func GetLetterHandler(w http.ResponseWriter, r *http.Request, s storage.Storage,
 		}
 	}
 
-	http.Error(w, "Not Found", http.StatusNotFound)
+	HandleError(w, r, apperrors.NotFound(nil), "GetLetterHandler", "findLetter")
 }

--- a/cmd/web/login.go
+++ b/cmd/web/login.go
@@ -1,13 +1,14 @@
 package web
 
 import (
-	"errors"
 	"log"
 	"net/http"
+
+	apperrors "timterests/internal/errors"
+
 	"timterests/internal/auth"
 )
 
-// LoginHandler handles user authentication and login requests.
 func LoginHandler(w http.ResponseWriter, r *http.Request, a *auth.Auth) {
 	if r.Method == http.MethodPost {
 		email := r.FormValue("email")
@@ -22,14 +23,12 @@ func LoginHandler(w http.ResponseWriter, r *http.Request, a *auth.Auth) {
 
 		log.Printf("login: authentication failed: %v", err)
 
-		// Distinguish invalid credentials (401) from unexpected server errors (500).
-		if err != nil && !errors.Is(err, auth.ErrInvalidCredentials) {
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		if err != nil && !apperrors.Is(err, auth.ErrInvalidCredentials) {
+			HandleError(w, r, apperrors.InternalServerError(err), "LoginHandler", "authenticate")
 
 			return
 		}
 
-		// Re-render the login page with an inline error rather than navigating away.
 		component := LoginPage("Incorrect email or password.")
 		if r.Header.Get("Hx-Request") == "true" {
 			component = LoginContainer("Incorrect email or password.")
@@ -37,14 +36,12 @@ func LoginHandler(w http.ResponseWriter, r *http.Request, a *auth.Auth) {
 
 		renderErr := renderHTML(w, r, http.StatusUnauthorized, component)
 		if renderErr != nil {
-			log.Printf("login: failed to render error page: %v", renderErr)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			HandleError(w, r, apperrors.RenderFailed(renderErr), "LoginHandler", "renderError")
 		}
 
 		return
 	}
 
-	// Render the login page for the initial load.
 	component := LoginPage("")
 	if r.Header.Get("Hx-Request") == "true" {
 		component = LoginContainer("")
@@ -52,7 +49,6 @@ func LoginHandler(w http.ResponseWriter, r *http.Request, a *auth.Auth) {
 
 	err := renderHTML(w, r, http.StatusOK, component)
 	if err != nil {
-		log.Printf("login: failed to render page: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		HandleError(w, r, apperrors.RenderFailed(err), "LoginHandler", "render")
 	}
 }

--- a/cmd/web/projects.go
+++ b/cmd/web/projects.go
@@ -1,9 +1,11 @@
 package web
 
 import (
-	"log"
 	"net/http"
 	"reflect"
+
+	apperrors "timterests/internal/errors"
+
 	"timterests/internal/auth"
 	"timterests/internal/model"
 	"timterests/internal/service"
@@ -12,8 +14,6 @@ import (
 	"github.com/a-h/templ"
 )
 
-// ProjectsPageHandler handles requests to the projects page,
-// ensuring authentication and rendering the appropriate content.
 func ProjectsPageHandler(w http.ResponseWriter, r *http.Request, s storage.Storage, currentTag, design string) {
 	var (
 		component templ.Component
@@ -22,8 +22,7 @@ func ProjectsPageHandler(w http.ResponseWriter, r *http.Request, s storage.Stora
 
 	projects, err := service.ListProjects(r.Context(), s, currentTag)
 	if err != nil {
-		log.Printf("ProjectsPageHandler: failed to fetch projects: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		HandleError(w, r, apperrors.StorageFailed(err), "ProjectsPageHandler", "listProjects")
 
 		return
 	}
@@ -41,16 +40,14 @@ func ProjectsPageHandler(w http.ResponseWriter, r *http.Request, s storage.Stora
 
 	err = renderHTML(w, r, http.StatusOK, component)
 	if err != nil {
-		log.Printf("ProjectsPageHandler: failed to render: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		HandleError(w, r, apperrors.RenderFailed(err), "ProjectsPageHandler", "render")
 	}
 }
 
-// GetProjectHandler handles requests to get a specific project by its ID.
 func GetProjectHandler(w http.ResponseWriter, r *http.Request, s storage.Storage, projectID string, a *auth.Auth) {
 	projects, err := service.ListProjects(r.Context(), s, "all")
 	if err != nil {
-		http.Error(w, "Failed to fetch projects", http.StatusInternalServerError)
+		HandleError(w, r, apperrors.StorageFailed(err), "GetProjectHandler", "listProjects")
 
 		return
 	}
@@ -59,8 +56,7 @@ func GetProjectHandler(w http.ResponseWriter, r *http.Request, s storage.Storage
 		if project.ID == projectID {
 			body, err := s.GetDocumentBody(r.Context(), project.S3Key)
 			if err != nil {
-				log.Printf("GetProjectHandler: failed to load body for %s: %v", project.S3Key, err)
-				http.Error(w, "Not Found", http.StatusNotFound)
+				HandleError(w, r, apperrors.NotFound(err), "GetProjectHandler", "getBody")
 
 				return
 			}
@@ -83,8 +79,7 @@ func GetProjectHandler(w http.ResponseWriter, r *http.Request, s storage.Storage
 
 			err = renderHTML(w, r, http.StatusOK, component)
 			if err != nil {
-				log.Printf("GetProjectHandler: failed to render: %v", err)
-				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				HandleError(w, r, apperrors.RenderFailed(err), "GetProjectHandler", "render")
 
 				return
 			}
@@ -93,5 +88,5 @@ func GetProjectHandler(w http.ResponseWriter, r *http.Request, s storage.Storage
 		}
 	}
 
-	http.Error(w, "Not Found", http.StatusNotFound)
+	HandleError(w, r, apperrors.NotFound(nil), "GetProjectHandler", "findProject")
 }

--- a/cmd/web/reading_list.go
+++ b/cmd/web/reading_list.go
@@ -1,9 +1,11 @@
 package web
 
 import (
-	"log"
 	"net/http"
 	"reflect"
+
+	apperrors "timterests/internal/errors"
+
 	"timterests/internal/auth"
 	"timterests/internal/model"
 	"timterests/internal/service"
@@ -12,7 +14,6 @@ import (
 	"github.com/a-h/templ"
 )
 
-// ReadingListPageHandler handles requests to the reading list page and renders book collections.
 func ReadingListPageHandler(w http.ResponseWriter, r *http.Request, s storage.Storage, currentTag, design string) {
 	var (
 		component templ.Component
@@ -21,8 +22,7 @@ func ReadingListPageHandler(w http.ResponseWriter, r *http.Request, s storage.St
 
 	books, err := service.ListBooks(r.Context(), s, currentTag)
 	if err != nil {
-		log.Printf("ReadingListPageHandler: failed to fetch reading list: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		HandleError(w, r, apperrors.StorageFailed(err), "ReadingListPageHandler", "listBooks")
 
 		return
 	}
@@ -40,16 +40,14 @@ func ReadingListPageHandler(w http.ResponseWriter, r *http.Request, s storage.St
 
 	err = renderHTML(w, r, http.StatusOK, component)
 	if err != nil {
-		log.Printf("ReadingListPageHandler: failed to render: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		HandleError(w, r, apperrors.RenderFailed(err), "ReadingListPageHandler", "render")
 	}
 }
 
-// GetReadingListBook retrieves and renders a specific book by ID.
 func GetReadingListBook(w http.ResponseWriter, r *http.Request, s storage.Storage, bookID string, a *auth.Auth) {
 	books, err := service.ListBooks(r.Context(), s, "all")
 	if err != nil {
-		http.Error(w, "Failed to fetch books", http.StatusInternalServerError)
+		HandleError(w, r, apperrors.StorageFailed(err), "GetReadingListBook", "listBooks")
 
 		return
 	}
@@ -58,8 +56,7 @@ func GetReadingListBook(w http.ResponseWriter, r *http.Request, s storage.Storag
 		if book.ID == bookID {
 			body, err := s.GetDocumentBody(r.Context(), book.S3Key)
 			if err != nil {
-				log.Printf("GetReadingListBook: failed to load body for %s: %v", book.S3Key, err)
-				http.Error(w, "Not Found", http.StatusNotFound)
+				HandleError(w, r, apperrors.NotFound(err), "GetReadingListBook", "getBody")
 
 				return
 			}
@@ -82,8 +79,7 @@ func GetReadingListBook(w http.ResponseWriter, r *http.Request, s storage.Storag
 
 			err = renderHTML(w, r, http.StatusOK, component)
 			if err != nil {
-				log.Printf("GetReadingListBook: failed to render: %v", err)
-				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				HandleError(w, r, apperrors.RenderFailed(err), "GetReadingListBook", "render")
 
 				return
 			}
@@ -92,5 +88,5 @@ func GetReadingListBook(w http.ResponseWriter, r *http.Request, s storage.Storag
 		}
 	}
 
-	http.Error(w, "Not Found", http.StatusNotFound)
+	HandleError(w, r, apperrors.NotFound(nil), "GetReadingListBook", "findBook")
 }

--- a/cmd/web/writer.go
+++ b/cmd/web/writer.go
@@ -11,6 +11,7 @@ import (
 
 	"timterests/internal/ai"
 	"timterests/internal/auth"
+	apperrors "timterests/internal/errors"
 	"timterests/internal/model"
 	"timterests/internal/service"
 	"timterests/internal/storage"
@@ -18,7 +19,6 @@ import (
 	"github.com/a-h/templ"
 )
 
-// WriterFormData holds all data needed to render the writer form.
 type WriterFormData struct {
 	Doc     model.Document
 	Body    string
@@ -26,7 +26,6 @@ type WriterFormData struct {
 	Fields  templ.Component
 }
 
-// emptyFormData returns a zero-value WriterFormData for a new document of the given type.
 func emptyFormData(docType string) WriterFormData {
 	switch docType {
 	case "projects":
@@ -41,14 +40,13 @@ func emptyFormData(docType string) WriterFormData {
 		doc := model.Letter{}
 
 		return WriterFormData{Doc: doc.Document, DocType: "letters", Fields: LetterFormContent(&doc)}
-	default: // "articles" and fallback
+	default:
 		doc := model.Article{}
 
 		return WriterFormData{Doc: doc.Document, DocType: "articles", Fields: ArticleFormContent(&doc)}
 	}
 }
 
-// WriterPageHandler handles requests to the writer page, ensuring authentication and rendering the appropriate content.
 func WriterPageHandler(
 	w http.ResponseWriter,
 	r *http.Request,
@@ -71,8 +69,7 @@ func WriterPageHandler(
 	if key != "" {
 		data, err = getTypeContentRaw(r.Context(), docType, key, typeID, s)
 		if err != nil {
-			log.Printf("WriterPageHandler: failed to load document: %v", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			HandleError(w, r, apperrors.StorageFailed(err), "WriterPageHandler", "loadDocument")
 
 			return
 		}
@@ -88,12 +85,10 @@ func WriterPageHandler(
 
 	err = renderHTML(w, r, http.StatusOK, component)
 	if err != nil {
-		log.Printf("WriterPageHandler: failed to render: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		HandleError(w, r, apperrors.RenderFailed(err), "WriterPageHandler", "render")
 	}
 }
 
-// WriteDocumentHandler handles the submission of the writer form to create or update documents.
 func WriteDocumentHandler(w http.ResponseWriter, r *http.Request, s storage.Storage, a *auth.Auth) {
 	if !a.IsAuthenticated(r) {
 		http.Redirect(w, r, "/login", http.StatusSeeOther)
@@ -102,31 +97,28 @@ func WriteDocumentHandler(w http.ResponseWriter, r *http.Request, s storage.Stor
 	}
 
 	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		HandleError(w, r, apperrors.MethodNotAllowed(), "WriteDocumentHandler", "checkMethod")
 
 		return
 	}
 
 	formData, s3Upload, err := extractFormData(r)
 	if err != nil {
-		http.Error(w, "Failed to parse form data", http.StatusBadRequest)
-		log.Printf("Error parsing form: %v", err)
+		HandleError(w, r, apperrors.ParseFormFailed(err), "WriteDocumentHandler", "extractForm")
 
 		return
 	}
 
 	docType, err := extractDocType(formData)
 	if err != nil {
-		log.Printf("WriteDocumentHandler: invalid document type: %v", err)
-		http.Error(w, "Bad Request", http.StatusBadRequest)
+		HandleError(w, r, apperrors.BadRequest(err), "WriteDocumentHandler", "extractDocType")
 
 		return
 	}
 
 	slug, err := generateSlug(formData, docType)
 	if err != nil {
-		log.Printf("WriteDocumentHandler: invalid filename data: %v", err)
-		http.Error(w, "Bad Request", http.StatusBadRequest)
+		HandleError(w, r, apperrors.BadRequest(err), "WriteDocumentHandler", "generateSlug")
 
 		return
 	}
@@ -136,24 +128,21 @@ func WriteDocumentHandler(w http.ResponseWriter, r *http.Request, s storage.Stor
 
 	yamlPath, err := storage.LocalPath(s.BaseDir, yamlFilename)
 	if err != nil {
-		http.Error(w, "Invalid file path", http.StatusBadRequest)
-		log.Printf("Invalid local yaml path: %v", err)
+		HandleError(w, r, apperrors.BadRequest(err), "WriteDocumentHandler", "yamlPath")
 
 		return
 	}
 
 	mdPath, err := storage.LocalPath(s.BaseDir, mdFilename)
 	if err != nil {
-		http.Error(w, "Invalid file path", http.StatusBadRequest)
-		log.Printf("Invalid local md path: %v", err)
+		HandleError(w, r, apperrors.BadRequest(err), "WriteDocumentHandler", "mdPath")
 
 		return
 	}
 
 	err = storage.WriteMarkdownDocument(yamlPath, mdPath, formData)
 	if err != nil {
-		http.Error(w, "Failed to save document", http.StatusInternalServerError)
-		log.Printf("Error writing document: %v", err)
+		HandleError(w, r, apperrors.StorageFailed(err), "WriteDocumentHandler", "writeDocument")
 
 		return
 	}
@@ -161,14 +150,14 @@ func WriteDocumentHandler(w http.ResponseWriter, r *http.Request, s storage.Stor
 	if s3Upload {
 		err = s.UploadFileToS3(r.Context(), yamlFilename)
 		if err != nil {
-			http.Error(w, "Failed to upload document to storage", http.StatusInternalServerError)
+			HandleError(w, r, apperrors.StorageFailed(err), "WriteDocumentHandler", "uploadYaml")
 
 			return
 		}
 
 		err = s.UploadFileToS3(r.Context(), mdFilename)
 		if err != nil {
-			http.Error(w, "Failed to upload document to storage", http.StatusInternalServerError)
+			HandleError(w, r, apperrors.StorageFailed(err), "WriteDocumentHandler", "uploadMd")
 
 			return
 		}
@@ -177,7 +166,6 @@ func WriteDocumentHandler(w http.ResponseWriter, r *http.Request, s storage.Stor
 	http.Redirect(w, r, "/writer", http.StatusSeeOther)
 }
 
-// WriterSuggestionHandler handles AI-powered content suggestions for the writer.
 func WriterSuggestionHandler(w http.ResponseWriter, r *http.Request, s storage.Storage, a *auth.Auth) {
 	if !a.IsAuthenticated(r) {
 		http.Redirect(w, r, "/login", http.StatusSeeOther)
@@ -187,8 +175,7 @@ func WriterSuggestionHandler(w http.ResponseWriter, r *http.Request, s storage.S
 
 	err := r.ParseForm()
 	if err != nil {
-		http.Error(w, "Failed to parse form", http.StatusBadRequest)
-		log.Printf("Error parsing form in WriterSuggestionHandler: %v", err)
+		HandleError(w, r, apperrors.ParseFormFailed(err), "WriterSuggestionHandler", "parseForm")
 
 		return
 	}
@@ -197,10 +184,9 @@ func WriterSuggestionHandler(w http.ResponseWriter, r *http.Request, s storage.S
 	if strings.TrimSpace(bodyContent) == "" {
 		component := AISuggestionError("Please enter some content in the body field first.")
 
-		err := renderHTML(w, r, http.StatusOK, component)
-		if err != nil {
-			log.Printf("Error rendering in WriterSuggestionHandler: %v", err)
-			http.Error(w, "Service temporarily unavailable", http.StatusInternalServerError)
+		renderErr := renderHTML(w, r, http.StatusOK, component)
+		if renderErr != nil {
+			HandleError(w, r, apperrors.RenderFailed(renderErr), "WriterSuggestionHandler", "renderEmpty")
 		}
 
 		return
@@ -208,19 +194,18 @@ func WriterSuggestionHandler(w http.ResponseWriter, r *http.Request, s storage.S
 
 	docType := r.FormValue("document-type")
 	if strings.TrimSpace(docType) == "" {
-		docType = "articles" // default
+		docType = "articles"
 	}
 
 	systemInstruction, err := s.GetPromptContent(r.Context(), docType)
 	if err != nil {
-		log.Printf("Failed to load system prompt for docType %q: %v", docType, err) // #nosec G706
+		log.Printf("Failed to load system prompt for docType %q: %v", docType, err)
 
 		component := AISuggestionError("AI suggestions are temporarily unavailable. Please try again later.")
 
-		err = component.Render(r.Context(), w)
-		if err != nil {
-			http.Error(w, "Service temporarily unavailable", http.StatusInternalServerError)
-			log.Printf("Error rendering in WriterSuggestionHandler: %v", err)
+		renderErr := renderHTML(w, r, http.StatusOK, component)
+		if renderErr != nil {
+			HandleError(w, r, apperrors.RenderFailed(renderErr), "WriterSuggestionHandler", "renderPromptError")
 		}
 
 		return
@@ -232,10 +217,9 @@ func WriterSuggestionHandler(w http.ResponseWriter, r *http.Request, s storage.S
 
 		component := AISuggestionError("Failed to get AI suggestion. Please try again later.")
 
-		err := renderHTML(w, r, http.StatusOK, component)
-		if err != nil {
-			log.Printf("Error rendering in WriterSuggestionHandler: %v", err)
-			http.Error(w, "Service temporarily unavailable", http.StatusInternalServerError)
+		renderErr := renderHTML(w, r, http.StatusOK, component)
+		if renderErr != nil {
+			HandleError(w, r, apperrors.RenderFailed(renderErr), "WriterSuggestionHandler", "renderAIError")
 		}
 
 		return
@@ -245,20 +229,14 @@ func WriterSuggestionHandler(w http.ResponseWriter, r *http.Request, s storage.S
 
 	err = renderHTML(w, r, http.StatusOK, component)
 	if err != nil {
-		log.Printf("Error rendering AISuggestionResponse in WriterSuggestionHandler: %v", err)
-		http.Error(w, "Service temporarily unavailable", http.StatusInternalServerError)
-
-		return
+		HandleError(w, r, apperrors.RenderFailed(err), "WriterSuggestionHandler", "renderSuggestion")
 	}
 }
 
-// metaSetter is satisfied by any type whose pointer embeds *model.Document.
 type metaSetter interface {
 	SetMeta(id, key string)
 }
 
-// loadRawDoc initialises a zero-value T, sets its metadata, fetches the raw
-// (non-HTML-converted) file from storage, and returns Content with the doc and raw markdown body.
 func loadRawDoc[T any, PT interface {
 	*T
 	metaSetter
@@ -298,7 +276,6 @@ func StripDocumentHeaders(raw string) string {
 	return raw
 }
 
-// getTypeContentRaw retrieves content for editing, keeping the body as raw markdown.
 func getTypeContentRaw(ctx context.Context, docType, key string, id int, s storage.Storage) (WriterFormData, error) {
 	idStr := strconv.Itoa(id)
 
@@ -337,7 +314,6 @@ func getTypeContentRaw(ctx context.Context, docType, key string, id int, s stora
 	}
 }
 
-// extractFormData parses form data and returns the processed data, S3 upload flag, and any error.
 func extractFormData(r *http.Request) (map[string]any, bool, error) {
 	err := r.ParseForm()
 	if err != nil {
@@ -365,7 +341,6 @@ func extractFormData(r *http.Request) (map[string]any, bool, error) {
 	return formData, s3Upload, nil
 }
 
-// extractDocType validates and extracts the document type from form data.
 func extractDocType(formData map[string]any) (string, error) {
 	docTypeAny, ok := formData["document-type"]
 	if !ok {
@@ -382,7 +357,6 @@ func extractDocType(formData map[string]any) (string, error) {
 	return docType, nil
 }
 
-// generateSlug creates a base filename slug (without extension) from the document type and form data.
 func generateSlug(formData map[string]any, docType string) (string, error) {
 	title, ok := formData["title"].(string)
 	if !ok || strings.TrimSpace(title) == "" {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,159 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+type Severity string
+
+const (
+	SeverityCritical Severity = "CRITICAL"
+	SeverityError    Severity = "ERROR"
+	SeverityWarning  Severity = "WARNING"
+	SeverityInfo     Severity = "INFO"
+)
+
+type AppError struct {
+	Code       string
+	Message    string
+	Severity   Severity
+	HTTPStatus int
+	Handler    string
+	Action     string
+	Err        error
+}
+
+func (e *AppError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("[%s] %s: %v", e.Code, e.Message, e.Err)
+	}
+
+	return fmt.Sprintf("[%s] %s", e.Code, e.Message)
+}
+
+func (e *AppError) Unwrap() error {
+	return e.Err
+}
+
+func (e *AppError) WithHandler(handler, action string) *AppError {
+	clone := *e
+
+	clone.Handler = handler
+	clone.Action = action
+
+	return &clone
+}
+
+func (e *AppError) WithErr(err error) *AppError {
+	clone := *e
+
+	clone.Err = err
+
+	return &clone
+}
+
+type errorDef struct {
+	Code       string
+	Message    string
+	Severity   Severity
+	HTTPStatus int
+}
+
+func getRegistry() map[string]errorDef {
+	return map[string]errorDef{
+		"INTERNAL_SERVER_ERROR": {
+			"INTERNAL_SERVER_ERROR",
+			"Something went wrong. Please try again later.",
+			SeverityError, http.StatusInternalServerError,
+		},
+		"NOT_FOUND": {
+			"NOT_FOUND",
+			"The requested resource could not be found.",
+			SeverityWarning, http.StatusNotFound,
+		},
+		"BAD_REQUEST": {
+			"BAD_REQUEST",
+			"The request contained invalid data.",
+			SeverityWarning, http.StatusBadRequest,
+		},
+		"UNAUTHORIZED": {
+			"UNAUTHORIZED",
+			"Authentication required.",
+			SeverityWarning, http.StatusUnauthorized,
+		},
+		"FORBIDDEN": {
+			"FORBIDDEN",
+			"You don't have permission to perform this action.",
+			SeverityWarning, http.StatusForbidden,
+		},
+		"METHOD_NOT_ALLOWED": {
+			"METHOD_NOT_ALLOWED",
+			"Method not allowed.",
+			SeverityWarning, http.StatusMethodNotAllowed,
+		},
+		"STORAGE_FAILED": {
+			"STORAGE_FAILED",
+			"Failed to access storage.",
+			SeverityError, http.StatusInternalServerError,
+		},
+		"RENDER_FAILED": {
+			"RENDER_FAILED",
+			"Failed to render page.",
+			SeverityError, http.StatusInternalServerError,
+		},
+		"PARSE_FORM_FAILED": {
+			"PARSE_FORM_FAILED",
+			"Failed to parse form data.",
+			SeverityWarning, http.StatusBadRequest,
+		},
+		"LOGIN_FAILED": {
+			"LOGIN_FAILED",
+			"Incorrect email or password.",
+			SeverityWarning, http.StatusUnauthorized,
+		},
+		"PANIC_RECOVERED": {
+			"PANIC_RECOVERED",
+			"An unexpected error occurred.",
+			SeverityCritical, http.StatusInternalServerError,
+		},
+	}
+}
+
+func newFromDef(code string) *AppError {
+	registry := getRegistry()
+
+	def, ok := registry[code]
+	if !ok {
+		def = registry["INTERNAL_SERVER_ERROR"]
+		def.Code = code
+	}
+
+	return &AppError{
+		Code:       def.Code,
+		Message:    def.Message,
+		Severity:   def.Severity,
+		HTTPStatus: def.HTTPStatus,
+	}
+}
+
+func New(code string, err error) *AppError {
+	return newFromDef(code).WithErr(err)
+}
+
+func InternalServerError(err error) *AppError { return New("INTERNAL_SERVER_ERROR", err) }
+func NotFound(err error) *AppError            { return New("NOT_FOUND", err) }
+func BadRequest(err error) *AppError          { return New("BAD_REQUEST", err) }
+func Unauthorized(err error) *AppError        { return New("UNAUTHORIZED", err) }
+func Forbidden() *AppError                    { return newFromDef("FORBIDDEN") }
+func MethodNotAllowed() *AppError             { return newFromDef("METHOD_NOT_ALLOWED") }
+func StorageFailed(err error) *AppError       { return New("STORAGE_FAILED", err) }
+func RenderFailed(err error) *AppError        { return New("RENDER_FAILED", err) }
+func ParseFormFailed(err error) *AppError     { return New("PARSE_FORM_FAILED", err) }
+func LoginFailed(err error) *AppError         { return New("LOGIN_FAILED", err) }
+func PanicRecovered(err error) *AppError      { return New("PANIC_RECOVERED", err) }
+
+func Is(err, target error) bool { return errors.Is(err, target) }
+
+func As(err error, target any) bool { return errors.As(err, target) }

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,0 +1,134 @@
+package errors_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	apperrors "timterests/internal/errors"
+)
+
+func TestAppError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Error without underlying error", func(t *testing.T) {
+		t.Parallel()
+
+		err := apperrors.NotFound(nil)
+		want := "[NOT_FOUND] The requested resource could not be found."
+
+		if err.Error() != want {
+			t.Fatalf("got %q, want %q", err.Error(), want)
+		}
+	})
+
+	t.Run("Error with underlying error", func(t *testing.T) {
+		t.Parallel()
+
+		err := apperrors.StorageFailed(errors.New("disk full"))
+
+		if err.Err == nil {
+			t.Fatal("expected underlying error")
+		}
+
+		if err.HTTPStatus != http.StatusInternalServerError {
+			t.Fatalf("got status %d, want %d", err.HTTPStatus, http.StatusInternalServerError)
+		}
+	})
+
+	t.Run("Unwrap returns underlying error", func(t *testing.T) {
+		t.Parallel()
+
+		inner := errors.New("original")
+		err := apperrors.InternalServerError(inner)
+
+		if !errors.Is(err.Unwrap(), inner) {
+			t.Fatal("Unwrap did not return the original error")
+		}
+	})
+
+	t.Run("WithHandler creates independent copy", func(t *testing.T) {
+		t.Parallel()
+
+		err := apperrors.BadRequest(nil)
+		withCtx := err.WithHandler("TestHandler", "doThing")
+
+		if withCtx.Handler != "TestHandler" {
+			t.Fatalf("got handler %q, want TestHandler", withCtx.Handler)
+		}
+
+		if err.Handler != "" {
+			t.Fatal("original was mutated")
+		}
+	})
+
+	t.Run("Unknown code falls back to INTERNAL_SERVER_ERROR", func(t *testing.T) {
+		t.Parallel()
+
+		err := apperrors.New("TOTALLY_MADE_UP", nil)
+
+		if err.Code != "TOTALLY_MADE_UP" {
+			t.Fatalf("got code %q, want TOTALLY_MADE_UP", err.Code)
+		}
+
+		if err.HTTPStatus != http.StatusInternalServerError {
+			t.Fatalf("got status %d, want %d", err.HTTPStatus, http.StatusInternalServerError)
+		}
+	})
+}
+
+func TestClassify(t *testing.T) {
+	t.Parallel()
+
+	t.Run("classifies AppError as-is", func(t *testing.T) {
+		t.Parallel()
+
+		original := apperrors.NotFound(nil)
+		classified := apperrors.Classify(original)
+
+		if classified.Code != "NOT_FOUND" {
+			t.Fatalf("got code %q, want NOT_FOUND", classified.Code)
+		}
+	})
+
+	t.Run("wraps plain error as INTERNAL_SERVER_ERROR", func(t *testing.T) {
+		t.Parallel()
+
+		classified := apperrors.Classify(errors.New("something broke"))
+
+		if classified.Code != "INTERNAL_SERVER_ERROR" {
+			t.Fatalf("got code %q, want INTERNAL_SERVER_ERROR", classified.Code)
+		}
+	})
+}
+
+func TestSeverityConstructors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		err      *apperrors.AppError
+		wantCode string
+		wantSev  apperrors.Severity
+	}{
+		{"Forbidden", apperrors.Forbidden(), "FORBIDDEN", apperrors.SeverityWarning},
+		{"MethodNotAllowed", apperrors.MethodNotAllowed(), "METHOD_NOT_ALLOWED", apperrors.SeverityWarning},
+		{"PanicRecovered", apperrors.PanicRecovered(nil), "PANIC_RECOVERED", apperrors.SeverityCritical},
+		{"RenderFailed", apperrors.RenderFailed(nil), "RENDER_FAILED", apperrors.SeverityError},
+		{"ParseFormFailed", apperrors.ParseFormFailed(nil), "PARSE_FORM_FAILED", apperrors.SeverityWarning},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tc.err.Code != tc.wantCode {
+				t.Fatalf("got code %q, want %q", tc.err.Code, tc.wantCode)
+			}
+
+			if tc.err.Severity != tc.wantSev {
+				t.Fatalf("got severity %q, want %q", tc.err.Severity, tc.wantSev)
+			}
+		})
+	}
+}

--- a/internal/errors/handler.go
+++ b/internal/errors/handler.go
@@ -1,0 +1,69 @@
+package errors
+
+import (
+	"errors"
+	"log"
+	"runtime/debug"
+)
+
+const (
+	colorReset  = "\033[0m"
+	colorRed    = "\033[31m"
+	colorYellow = "\033[33m"
+	colorCyan   = "\033[36m"
+)
+
+// LogError logs an AppError with consistent formatting and severity-based coloring.
+func LogError(appErr *AppError) {
+	if appErr == nil {
+		return
+	}
+
+	color := severityColor(appErr.Severity)
+
+	handler := appErr.Handler
+	if handler == "" {
+		handler = "-"
+	}
+
+	action := appErr.Action
+	if action == "" {
+		action = "-"
+	}
+
+	msg := appErr.Message
+	if appErr.Err != nil {
+		msg += ": " + appErr.Err.Error()
+	}
+
+	log.Printf("%s[%s] %s | handler=%s action=%s | %s%s",
+		color, appErr.Severity, appErr.Code, handler, action, msg, colorReset)
+
+	if appErr.Severity == SeverityCritical {
+		log.Printf("%s[STACK] %s%s", color, string(debug.Stack()), colorReset)
+	}
+}
+
+// Classify converts any error into an *AppError. If it's already an *AppError, it's
+// returned as-is. Otherwise it's wrapped as INTERNAL_SERVER_ERROR.
+func Classify(err error) *AppError {
+	var appErr *AppError
+	if errors.As(err, &appErr) {
+		return appErr
+	}
+
+	return InternalServerError(err)
+}
+
+func severityColor(s Severity) string {
+	switch s {
+	case SeverityCritical, SeverityError:
+		return colorRed
+	case SeverityWarning:
+		return colorYellow
+	case SeverityInfo:
+		return colorCyan
+	default:
+		return ""
+	}
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"runtime/debug"
 	"strconv"
 
 	"timterests/cmd/web"
+	apperrors "timterests/internal/errors"
 	"timterests/internal/service"
 )
 
@@ -56,8 +56,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 
 		err := r.ParseForm()
 		if err != nil {
-			log.Printf("writer: failed to parse form: %v", err)
-			http.Error(w, "Bad Request", http.StatusBadRequest)
+			web.HandleError(w, r, apperrors.ParseFormFailed(err), "writer", "parseForm")
 
 			return
 		}
@@ -73,8 +72,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 
 			typeID, err = strconv.Atoi(typeIDString)
 			if err != nil {
-				log.Printf("writer: invalid type-id %q: %v", typeIDString, err)
-				http.Error(w, fmt.Sprintf("type-id must be an integer, got %q", typeIDString), http.StatusBadRequest)
+				web.HandleError(w, r, apperrors.BadRequest(err), "writer", "parseTypeID")
 
 				return
 			}
@@ -128,8 +126,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 	mux.Handle("/articles/list", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := service.ListArticles(r.Context(), *s.storage, "all")
 		if err != nil {
-			log.Printf("articles/list: %v", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			web.HandleError(w, r, apperrors.StorageFailed(err), "articles/list", "listArticles")
 
 			return
 		}
@@ -148,8 +145,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 	mux.Handle("/projects/list", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := service.ListProjects(r.Context(), *s.storage, "all")
 		if err != nil {
-			log.Printf("projects/list: %v", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			web.HandleError(w, r, apperrors.StorageFailed(err), "projects/list", "listProjects")
 
 			return
 		}
@@ -168,8 +164,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 	mux.Handle("/reading-list/list", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := service.ListBooks(r.Context(), *s.storage, "all")
 		if err != nil {
-			log.Printf("reading-list/list: %v", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			web.HandleError(w, r, apperrors.StorageFailed(err), "reading-list/list", "listBooks")
 
 			return
 		}
@@ -188,8 +183,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 	mux.Handle("/letters/list", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := service.ListLetters(r.Context(), *s.storage, "all")
 		if err != nil {
-			log.Printf("letters/list: %v", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			web.HandleError(w, r, apperrors.StorageFailed(err), "letters/list", "listLetters")
 
 			return
 		}
@@ -199,16 +193,12 @@ func (s *Server) RegisterRoutes() http.Handler {
 	return recoveryMiddleware(s.corsMiddleware(s.maxBytesMiddleware(mux)))
 }
 
-// recoveryMiddleware catches panics and returns a 500 rather than crashing the server.
-// It logs the panic value, stack trace, and request context for debugging.
 func recoveryMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if rec := recover(); rec != nil {
-				stack := debug.Stack()
-				log.Printf("panic recovered: %v\nrequest: %s %s\nstack:\n%s",
-					rec, r.Method, r.URL.Path, stack)
-				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				err := apperrors.PanicRecovered(fmt.Errorf("panic: %v", rec))
+				web.HandleError(w, r, err, r.URL.Path, r.Method)
 			}
 		}()
 


### PR DESCRIPTION
## Summary
- Adds `internal/errors` package with `AppError` type carrying code, message, severity, and HTTP status — single source of truth for all error surfaces
- Severity classification: `CRITICAL` (panics), `ERROR` (storage/render failures), `WARNING` (bad input, auth), `INFO`
- Structured logging with severity-colored console output and handler/action context
- Adds `HandleError` in `cmd/web` that renders styled HTML error pages via `error.templ` instead of plain-text `http.Error` responses
- `Classify` function auto-wraps unknown errors as `INTERNAL_SERVER_ERROR`
- Migrates all 11 handler files to use the unified error system
- Recovery middleware now renders the error page on panic instead of plain text
- Unit tests for `AppError`, `Classify`, and all severity constructors

## Test plan
- [ ] Visit a valid page and confirm normal rendering is unaffected
- [ ] Trigger a 404 (e.g. `/article?id=nonexistent`) and verify the styled error page renders
- [ ] Confirm server logs show structured `[SEVERITY] CODE | handler=X action=Y` format
- [ ] Run `make test` — all tests pass
- [ ] Run `golangci-lint run ./...` — 0 issues

Closes #64