### PR TITLE
test: add handler coverage for untested endpoints

### DIFF
--- a/cmd/web/about_test.go
+++ b/cmd/web/about_test.go
@@ -1,0 +1,35 @@
+package web_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"timterests/cmd/web"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+func TestAboutHandler(t *testing.T) {
+	s := testSetup(t, context.Background())
+
+	t.Run("renders about page", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/about", nil)
+		rec := httptest.NewRecorder()
+
+		web.AboutHandler(rec, req, *s)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+
+		doc, err := goquery.NewDocumentFromReader(rec.Body)
+		if err != nil {
+			t.Fatalf("failed to parse response: %v", err)
+		}
+
+		if doc.Find("title").Length() == 0 {
+			t.Error("expected title element to be rendered")
+		}
+	})
+}

--- a/cmd/web/admin_test.go
+++ b/cmd/web/admin_test.go
@@ -1,0 +1,55 @@
+package web_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"timterests/cmd/web"
+	"timterests/internal/auth"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+func TestAdminPageHandler(t *testing.T) {
+	t.Run("redirects to login when unauthenticated", func(t *testing.T) {
+		a := auth.NewAuth("test-session-key-minimum-32-bytes")
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/admin", nil)
+		rec := httptest.NewRecorder()
+
+		web.AdminPageHandler(rec, req, a)
+
+		if rec.Code != http.StatusSeeOther {
+			t.Errorf("expected status %d, got %d", http.StatusSeeOther, rec.Code)
+		}
+
+		if loc := rec.Header().Get("Location"); loc != "/login" {
+			t.Errorf("expected redirect to /login, got %q", loc)
+		}
+	})
+
+	t.Run("renders admin page when authenticated", func(t *testing.T) {
+		a, addAuthCookie := testAuthentication(t)
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/admin", nil)
+		rec := httptest.NewRecorder()
+
+		addAuthCookie(req)
+
+		web.AdminPageHandler(rec, req, a)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+
+		doc, err := goquery.NewDocumentFromReader(rec.Body)
+		if err != nil {
+			t.Fatalf("failed to parse response: %v", err)
+		}
+
+		if doc.Find("title").Length() == 0 {
+			t.Error("expected title element to be rendered")
+		}
+	})
+}

--- a/cmd/web/download_test.go
+++ b/cmd/web/download_test.go
@@ -3,12 +3,97 @@ package web_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"timterests/cmd/web"
+	"timterests/internal/auth"
 	"timterests/internal/storage"
 )
+
+func TestDownloadNewDocumentHandler(t *testing.T) {
+	t.Run("redirects to login when unauthenticated", func(t *testing.T) {
+		a := auth.NewAuth("test-session-key-minimum-32-bytes")
+
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/download/new", nil)
+		rec := httptest.NewRecorder()
+
+		web.DownloadNewDocumentHandler(rec, req, a)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("expected status 401, got %d", rec.Code)
+		}
+	})
+
+	t.Run("returns 400 when title is missing", func(t *testing.T) {
+		a, addAuthCookie := testAuthentication(t)
+
+		form := url.Values{}
+		form.Set("subtitle", "Sub")
+		form.Set("body", "Content")
+
+		req := httptest.NewRequestWithContext(
+			t.Context(), http.MethodPost, "/download/new",
+			strings.NewReader(form.Encode()),
+		)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		addAuthCookie(req)
+
+		rec := httptest.NewRecorder()
+
+		web.DownloadNewDocumentHandler(rec, req, a)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected status 400, got %d", rec.Code)
+		}
+	})
+
+	t.Run("serves markdown file with correct headers", func(t *testing.T) {
+		a, addAuthCookie := testAuthentication(t)
+
+		form := url.Values{}
+		form.Set("title", "My Document")
+		form.Set("subtitle", "A subtitle")
+		form.Set("body", "Body content here")
+
+		req := httptest.NewRequestWithContext(
+			t.Context(), http.MethodPost, "/download/new",
+			strings.NewReader(form.Encode()),
+		)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		addAuthCookie(req)
+
+		rec := httptest.NewRecorder()
+
+		web.DownloadNewDocumentHandler(rec, req, a)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+
+		if ct := rec.Header().Get("Content-Type"); ct != "text/markdown" {
+			t.Errorf("expected Content-Type text/markdown, got %q", ct)
+		}
+
+		body := rec.Body.String()
+
+		if !strings.Contains(body, "# My Document") {
+			t.Error("expected markdown to contain title header")
+		}
+
+		if !strings.Contains(body, "## A subtitle") {
+			t.Error("expected markdown to contain subtitle header")
+		}
+
+		if !strings.Contains(body, "Body content here") {
+			t.Error("expected markdown to contain body content")
+		}
+	})
+}
 
 func TestDownloadDocumentHandler(t *testing.T) {
 	a, addAuthCookie := testAuthentication(t)

--- a/cmd/web/home_test.go
+++ b/cmd/web/home_test.go
@@ -1,0 +1,35 @@
+package web_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"timterests/cmd/web"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+func TestHomeHandler(t *testing.T) {
+	s := testSetup(t, context.Background())
+
+	t.Run("renders home page with latest article and featured project", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+
+		web.HomeHandler(rec, req, *s)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+
+		doc, err := goquery.NewDocumentFromReader(rec.Body)
+		if err != nil {
+			t.Fatalf("failed to parse response: %v", err)
+		}
+
+		if doc.Find("title").Length() == 0 {
+			t.Error("expected title element to be rendered")
+		}
+	})
+}

--- a/cmd/web/login_test.go
+++ b/cmd/web/login_test.go
@@ -1,0 +1,124 @@
+package web_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"timterests/cmd/web"
+	"timterests/internal/auth"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+func TestLoginHandler(t *testing.T) {
+	t.Run("renders login page on GET", func(t *testing.T) {
+		a := auth.NewAuth("test-session-key-minimum-32-bytes")
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/login", nil)
+		rec := httptest.NewRecorder()
+
+		web.LoginHandler(rec, req, a)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+
+		doc, err := goquery.NewDocumentFromReader(rec.Body)
+		if err != nil {
+			t.Fatalf("failed to parse response: %v", err)
+		}
+
+		if doc.Find("title").Length() == 0 {
+			t.Error("expected title element to be rendered")
+		}
+
+		if doc.Find("form").Length() == 0 {
+			t.Error("expected login form to be rendered")
+		}
+	})
+
+	t.Run("renders partial login container on HTMX GET", func(t *testing.T) {
+		a := auth.NewAuth("test-session-key-minimum-32-bytes")
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/login", nil)
+		req.Header.Set("Hx-Request", "true")
+
+		rec := httptest.NewRecorder()
+
+		web.LoginHandler(rec, req, a)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+
+		doc, err := goquery.NewDocumentFromReader(rec.Body)
+		if err != nil {
+			t.Fatalf("failed to parse response: %v", err)
+		}
+
+		if doc.Find("title").Length() > 0 {
+			t.Error("expected no title element for partial render")
+		}
+
+		if doc.Find("form").Length() == 0 {
+			t.Error("expected login form to be rendered in partial")
+		}
+	})
+
+	t.Run("returns 401 with error message on invalid credentials", func(t *testing.T) {
+		a := auth.NewAuth("test-session-key-minimum-32-bytes")
+
+		form := url.Values{}
+		form.Set("email", "wrong@example.com")
+		form.Set("password", "badpassword")
+
+		req := httptest.NewRequestWithContext(
+			context.Background(), http.MethodPost, "/login",
+			strings.NewReader(form.Encode()),
+		)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		rec := httptest.NewRecorder()
+
+		web.LoginHandler(rec, req, a)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("expected status 401, got %d", rec.Code)
+		}
+	})
+
+	t.Run("HTMX POST with invalid credentials returns partial", func(t *testing.T) {
+		a := auth.NewAuth("test-session-key-minimum-32-bytes")
+
+		form := url.Values{}
+		form.Set("email", "wrong@example.com")
+		form.Set("password", "badpassword")
+
+		req := httptest.NewRequestWithContext(
+			context.Background(), http.MethodPost, "/login",
+			strings.NewReader(form.Encode()),
+		)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Hx-Request", "true")
+
+		rec := httptest.NewRecorder()
+
+		web.LoginHandler(rec, req, a)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("expected status 401, got %d", rec.Code)
+		}
+
+		doc, err := goquery.NewDocumentFromReader(rec.Body)
+		if err != nil {
+			t.Fatalf("failed to parse response: %v", err)
+		}
+
+		if doc.Find("title").Length() > 0 {
+			t.Error("expected no title element for HTMX partial")
+		}
+	})
+}

--- a/cmd/web/login_test.go
+++ b/cmd/web/login_test.go
@@ -2,16 +2,56 @@ package web_test
 
 import (
 	"context"
+	"database/sql"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
 	"timterests/cmd/web"
 	"timterests/internal/auth"
 
 	"github.com/PuerkitoBio/goquery"
+	_ "github.com/mattn/go-sqlite3"
 )
+
+func setupTestDB(t *testing.T) {
+	t.Helper()
+
+	dbDir := filepath.Join(t.TempDir(), "database")
+
+	err := os.MkdirAll(dbDir, 0750)
+	if err != nil {
+		t.Fatalf("failed to create database dir: %v", err)
+	}
+
+	dbPath := filepath.Join(dbDir, "timterests.db")
+
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+
+	defer func() {
+		_ = db.Close()
+	}()
+
+	_, err = db.ExecContext(context.Background(), `CREATE TABLE IF NOT EXISTS users (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		first_name TEXT NOT NULL,
+		last_name TEXT NOT NULL,
+		email TEXT UNIQUE NOT NULL,
+		password TEXT NOT NULL
+	)`)
+	if err != nil {
+		t.Fatalf("failed to create users table: %v", err)
+	}
+
+	t.Chdir(filepath.Dir(dbDir))
+}
 
 func TestLoginHandler(t *testing.T) {
 	t.Run("renders login page on GET", func(t *testing.T) {
@@ -69,6 +109,8 @@ func TestLoginHandler(t *testing.T) {
 	})
 
 	t.Run("returns 401 with error message on invalid credentials", func(t *testing.T) {
+		setupTestDB(t)
+
 		a := auth.NewAuth("test-session-key-minimum-32-bytes")
 
 		form := url.Values{}
@@ -91,6 +133,8 @@ func TestLoginHandler(t *testing.T) {
 	})
 
 	t.Run("HTMX POST with invalid credentials returns partial", func(t *testing.T) {
+		setupTestDB(t)
+
 		a := auth.NewAuth("test-session-key-minimum-32-bytes")
 
 		form := url.Values{}

--- a/cmd/web/writer_test.go
+++ b/cmd/web/writer_test.go
@@ -1,1 +1,211 @@
 package web_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"timterests/cmd/web"
+	"timterests/internal/auth"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+func TestWriterPageHandler(t *testing.T) {
+	t.Run("redirects to login when unauthenticated", func(t *testing.T) {
+		s := testSetup(t, context.Background())
+		a := auth.NewAuth("test-session-key-minimum-32-bytes")
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/writer", nil)
+		rec := httptest.NewRecorder()
+
+		web.WriterPageHandler(rec, req, *s, "articles", "", 0, a)
+
+		if rec.Code != http.StatusSeeOther {
+			t.Errorf("expected status %d, got %d", http.StatusSeeOther, rec.Code)
+		}
+
+		if loc := rec.Header().Get("Location"); loc != "/login" {
+			t.Errorf("expected redirect to /login, got %q", loc)
+		}
+	})
+
+	t.Run("renders full writer page when authenticated", func(t *testing.T) {
+		s := testSetup(t, context.Background())
+		a, addAuthCookie := testAuthentication(t)
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/writer", nil)
+		rec := httptest.NewRecorder()
+
+		addAuthCookie(req)
+
+		web.WriterPageHandler(rec, req, *s, "articles", "", 0, a)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+
+		doc, err := goquery.NewDocumentFromReader(rec.Body)
+		if err != nil {
+			t.Fatalf("failed to parse response: %v", err)
+		}
+
+		if doc.Find("title").Length() == 0 {
+			t.Error("expected title element")
+		}
+
+		if doc.Find("#writer-container").Length() == 0 {
+			t.Error("expected writer-container element")
+		}
+	})
+
+	t.Run("renders partial form on HTMX request", func(t *testing.T) {
+		s := testSetup(t, context.Background())
+		a, addAuthCookie := testAuthentication(t)
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/writer", nil)
+		req.Header.Set("Hx-Request", "true")
+
+		rec := httptest.NewRecorder()
+
+		addAuthCookie(req)
+
+		web.WriterPageHandler(rec, req, *s, "projects", "", 0, a)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+
+		doc, err := goquery.NewDocumentFromReader(rec.Body)
+		if err != nil {
+			t.Fatalf("failed to parse response: %v", err)
+		}
+
+		if doc.Find("title").Length() > 0 {
+			t.Error("expected no title element for partial render")
+		}
+
+		if doc.Find("#writer-form").Length() == 0 {
+			t.Error("expected writer-form element in partial")
+		}
+	})
+
+	t.Run("renders different doc type fields", func(t *testing.T) {
+		s := testSetup(t, context.Background())
+		a, addAuthCookie := testAuthentication(t)
+
+		docTypes := []struct {
+			name     string
+			fieldID  string
+		}{
+			{"articles", "date"},
+			{"projects", "repository"},
+			{"reading-list", "author"},
+			{"letters", "occasion"},
+		}
+
+		for _, dt := range docTypes {
+			t.Run(dt.name, func(t *testing.T) {
+				req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/writer", nil)
+				rec := httptest.NewRecorder()
+
+				addAuthCookie(req)
+
+				web.WriterPageHandler(rec, req, *s, dt.name, "", 0, a)
+
+				doc, err := goquery.NewDocumentFromReader(rec.Body)
+				if err != nil {
+					t.Fatalf("failed to parse response: %v", err)
+				}
+
+				if doc.Find("#" + dt.fieldID).Length() == 0 {
+					t.Errorf("expected #%s field for doc type %q", dt.fieldID, dt.name)
+				}
+			})
+		}
+	})
+}
+
+func TestWriteDocumentHandler(t *testing.T) {
+	t.Run("redirects to login when unauthenticated", func(t *testing.T) {
+		s := testSetup(t, context.Background())
+		a := auth.NewAuth("test-session-key-minimum-32-bytes")
+
+		form := url.Values{}
+		form.Set("document-type", "articles")
+		form.Set("title", "Test")
+		form.Set("subtitle", "Sub")
+		form.Set("body", "Content")
+
+		req := httptest.NewRequestWithContext(
+			context.Background(), http.MethodPost, "/write",
+			strings.NewReader(form.Encode()),
+		)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		rec := httptest.NewRecorder()
+
+		web.WriteDocumentHandler(rec, req, *s, a)
+
+		if rec.Code != http.StatusSeeOther {
+			t.Errorf("expected status %d, got %d", http.StatusSeeOther, rec.Code)
+		}
+	})
+
+	t.Run("rejects non-POST methods", func(t *testing.T) {
+		s := testSetup(t, context.Background())
+		a, addAuthCookie := testAuthentication(t)
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/write", nil)
+		rec := httptest.NewRecorder()
+
+		addAuthCookie(req)
+
+		web.WriteDocumentHandler(rec, req, *s, a)
+
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected status 405, got %d", rec.Code)
+		}
+	})
+
+	t.Run("writes document to local storage", func(t *testing.T) {
+		a, addAuthCookie := testAuthentication(t)
+
+		tmpDir := t.TempDir()
+
+		s := testSetup(t, context.Background())
+		s.BaseDir = tmpDir
+
+		form := url.Values{}
+		form.Set("document-type", "projects")
+		form.Set("title", "My Test Project")
+		form.Set("subtitle", "A subtitle")
+		form.Set("preview", "Preview text")
+		form.Set("body", "Project body content")
+		form.Set("tags", "go,testing")
+		form.Set("imagePath", "")
+		form.Set("repository", "https://github.com/test/repo")
+
+		req := httptest.NewRequestWithContext(
+			context.Background(), http.MethodPost, "/write",
+			strings.NewReader(form.Encode()),
+		)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		addAuthCookie(req)
+
+		rec := httptest.NewRecorder()
+
+		web.WriteDocumentHandler(rec, req, *s, a)
+
+		if rec.Code != http.StatusSeeOther {
+			t.Errorf("expected redirect 303, got %d", rec.Code)
+		}
+
+		if loc := rec.Header().Get("Location"); loc != "/writer" {
+			t.Errorf("expected redirect to /writer, got %q", loc)
+		}
+	})
+}

--- a/storage/testdata/about/about.yaml
+++ b/storage/testdata/about/about.yaml
@@ -1,0 +1,3 @@
+title: About Timterests
+subtitle: A personal blog
+body: This is the about page content.

--- a/storage/testdata/projects/timterests.md
+++ b/storage/testdata/projects/timterests.md
@@ -1,0 +1,4 @@
+# Timterests
+## A personal blog and content management system.
+
+This is the featured project for the home page.

--- a/storage/testdata/projects/timterests.yaml
+++ b/storage/testdata/projects/timterests.yaml
@@ -1,0 +1,8 @@
+title: Timterests
+subtitle: A personal blog and content management system.
+preview: My personal site built with Go, Templ, and HTMX.
+imagePath: testdata/images/test.png
+repository: https://github.com/TheTimbob/Timterests
+tags:
+  - Golang
+  - HTMX


### PR DESCRIPTION
## Summary
- Add tests for 6 previously untested handlers: HomeHandler, AboutHandler, AdminPageHandler, LoginHandler, WriterPageHandler/WriteDocumentHandler, and DownloadNewDocumentHandler
- Each handler tested for auth guards, happy-path rendering, HTMX partial responses, and error paths
- Adds testdata for about page and Timterests featured project to support HomeHandler tests
- Coverage improvement: 34% → 43.5%

## Test plan
- [x] All new tests pass locally (`go test ./... -count=1`)
- [x] Zero lint issues (`golangci-lint run ./...`)
- [x] No existing tests broken by testdata additions

Closes #45