### PR TITLE
feat: enhance health check endpoint with DB ping and proper status codes

### DIFF
--- a/internal/server/health_test.go
+++ b/internal/server/health_test.go
@@ -1,0 +1,90 @@
+package server_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"timterests/internal/server"
+	"timterests/internal/storage"
+)
+
+func TestHealthHandlerOK(t *testing.T) {
+	setupHealthTestDB(t)
+
+	s := &server.Server{
+		Storage: &storage.Storage{
+			UseS3:   false,
+			BaseDir: t.TempDir(),
+		},
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+
+	s.HealthHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var result map[string]any
+
+	err := json.Unmarshal(rec.Body.Bytes(), &result)
+	if err != nil {
+		t.Fatalf("failed to parse JSON response: %v", err)
+	}
+
+	if result["status"] != "ok" {
+		t.Errorf("expected status 'ok', got %q", result["status"])
+	}
+
+	if result["ts"] == nil || result["ts"] == "" {
+		t.Error("expected 'ts' field to be present and non-empty")
+	}
+
+	checks, ok := result["checks"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'checks' field to be an object")
+	}
+
+	if checks["storage"] != "ok" {
+		t.Errorf("expected storage 'ok', got %q", checks["storage"])
+	}
+
+	if checks["database"] != "ok" {
+		t.Errorf("expected database 'ok', got %q", checks["database"])
+	}
+}
+
+func TestHealthHandlerDegraded(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	s := &server.Server{
+		Storage: &storage.Storage{
+			UseS3:   false,
+			BaseDir: t.TempDir(),
+		},
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+
+	s.HealthHandler(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503, got %d", rec.Code)
+	}
+
+	var result map[string]any
+
+	err := json.Unmarshal(rec.Body.Bytes(), &result)
+	if err != nil {
+		t.Fatalf("failed to parse JSON response: %v", err)
+	}
+
+	if result["status"] != "degraded" {
+		t.Errorf("expected status 'degraded', got %q", result["status"])
+	}
+}

--- a/internal/server/helpers_test.go
+++ b/internal/server/helpers_test.go
@@ -1,0 +1,46 @@
+package server_test
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func setupHealthTestDB(t *testing.T) {
+	t.Helper()
+
+	dbDir := filepath.Join(t.TempDir(), "database")
+
+	err := os.MkdirAll(dbDir, 0750)
+	if err != nil {
+		t.Fatalf("failed to create database dir: %v", err)
+	}
+
+	dbPath := filepath.Join(dbDir, "timterests.db")
+
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+
+	defer func() {
+		_ = db.Close()
+	}()
+
+	_, err = db.ExecContext(context.Background(), `CREATE TABLE IF NOT EXISTS users (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		first_name TEXT NOT NULL,
+		last_name TEXT NOT NULL,
+		email TEXT UNIQUE NOT NULL,
+		password TEXT NOT NULL
+	)`)
+	if err != nil {
+		t.Fatalf("failed to create users table: %v", err)
+	}
+
+	t.Chdir(filepath.Dir(dbDir))
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -255,7 +255,9 @@ func (s *Server) HelloWorldHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *Server) healthHandler(w http.ResponseWriter, _ *http.Request) {
-	resp, err := json.Marshal(s.storage.Health())
+	result := s.storage.Health()
+
+	resp, err := json.Marshal(result)
 	if err != nil {
 		http.Error(w, "Failed to marshal health check response", http.StatusInternalServerError)
 
@@ -263,6 +265,10 @@ func (s *Server) healthHandler(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+
+	if !result.Healthy() {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
 
 	_, err = w.Write(resp)
 	if err != nil {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -28,16 +28,16 @@ func (s *Server) RegisterRoutes() http.Handler {
 
 	// Home Routes
 	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		web.HomeHandler(w, r, *s.storage)
+		web.HomeHandler(w, r, *s.Storage)
 	}))
 	mux.Handle("/home", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		web.HomeHandler(w, r, *s.storage)
+		web.HomeHandler(w, r, *s.Storage)
 	}))
 	mux.Handle("/web", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		web.HomeHandler(w, r, *s.storage)
+		web.HomeHandler(w, r, *s.Storage)
 	}))
 	mux.Handle("/web/home", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		web.HomeHandler(w, r, *s.storage)
+		web.HomeHandler(w, r, *s.Storage)
 	}))
 
 	mux.Handle("/admin", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -45,7 +45,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 	}))
 
 	mux.Handle("/admin/documents", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		web.AdminDocumentsPageHandler(w, r, *s.storage, s.auth)
+		web.AdminDocumentsPageHandler(w, r, *s.Storage, s.auth)
 	}))
 
 	mux.Handle("/writer", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -80,20 +80,20 @@ func (s *Server) RegisterRoutes() http.Handler {
 
 		key = r.FormValue("document-key")
 
-		web.WriterPageHandler(w, r, *s.storage, docType, key, typeID, s.auth)
+		web.WriterPageHandler(w, r, *s.Storage, docType, key, typeID, s.auth)
 	}))
 
 	mux.Handle("/write", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		web.WriteDocumentHandler(w, r, *s.storage, s.auth)
+		web.WriteDocumentHandler(w, r, *s.Storage, s.auth)
 	}))
 
 	mux.Handle("/write/suggest", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		web.WriterSuggestionHandler(w, r, *s.storage, s.auth)
+		web.WriterSuggestionHandler(w, r, *s.Storage, s.auth)
 	}))
 
 	mux.Handle("/download", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		documentKey := r.URL.Query().Get("key")
-		web.DownloadDocumentHandler(w, r, *s.storage, documentKey, s.auth)
+		web.DownloadDocumentHandler(w, r, *s.Storage, documentKey, s.auth)
 	}))
 
 	mux.Handle("/download/new", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -101,11 +101,11 @@ func (s *Server) RegisterRoutes() http.Handler {
 	}))
 
 	// Health check
-	mux.HandleFunc("/health", s.healthHandler)
+	mux.HandleFunc("/health", s.HealthHandler)
 
 	// About Routes
 	mux.Handle("/about", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		web.AboutHandler(w, r, *s.storage)
+		web.AboutHandler(w, r, *s.Storage)
 	}))
 
 	// Login Routes
@@ -117,14 +117,14 @@ func (s *Server) RegisterRoutes() http.Handler {
 	mux.Handle("/articles", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		design := r.URL.Query().Get("design")
 		tag := r.URL.Query().Get("tag")
-		web.ArticlesPageHandler(w, r, *s.storage, tag, design)
+		web.ArticlesPageHandler(w, r, *s.Storage, tag, design)
 	}))
 	mux.Handle("/article", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		articleID := r.URL.Query().Get("id")
-		web.GetArticleHandler(w, r, *s.storage, articleID, s.auth)
+		web.GetArticleHandler(w, r, *s.Storage, articleID, s.auth)
 	}))
 	mux.Handle("/articles/list", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, err := service.ListArticles(r.Context(), *s.storage, "all")
+		_, err := service.ListArticles(r.Context(), *s.Storage, "all")
 		if err != nil {
 			web.HandleError(w, r, apperrors.StorageFailed(err), "articles/list", "listArticles")
 
@@ -136,14 +136,14 @@ func (s *Server) RegisterRoutes() http.Handler {
 	mux.Handle("/projects", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		design := r.URL.Query().Get("design")
 		tag := r.URL.Query().Get("tag")
-		web.ProjectsPageHandler(w, r, *s.storage, tag, design)
+		web.ProjectsPageHandler(w, r, *s.Storage, tag, design)
 	}))
 	mux.Handle("/project", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		projectID := r.URL.Query().Get("id")
-		web.GetProjectHandler(w, r, *s.storage, projectID, s.auth)
+		web.GetProjectHandler(w, r, *s.Storage, projectID, s.auth)
 	}))
 	mux.Handle("/projects/list", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, err := service.ListProjects(r.Context(), *s.storage, "all")
+		_, err := service.ListProjects(r.Context(), *s.Storage, "all")
 		if err != nil {
 			web.HandleError(w, r, apperrors.StorageFailed(err), "projects/list", "listProjects")
 
@@ -155,14 +155,14 @@ func (s *Server) RegisterRoutes() http.Handler {
 	mux.Handle("/reading-list", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		design := r.URL.Query().Get("design")
 		tag := r.URL.Query().Get("tag")
-		web.ReadingListPageHandler(w, r, *s.storage, tag, design)
+		web.ReadingListPageHandler(w, r, *s.Storage, tag, design)
 	}))
 	mux.Handle("/book", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		articleID := r.URL.Query().Get("id")
-		web.GetReadingListBook(w, r, *s.storage, articleID, s.auth)
+		web.GetReadingListBook(w, r, *s.Storage, articleID, s.auth)
 	}))
 	mux.Handle("/reading-list/list", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, err := service.ListBooks(r.Context(), *s.storage, "all")
+		_, err := service.ListBooks(r.Context(), *s.Storage, "all")
 		if err != nil {
 			web.HandleError(w, r, apperrors.StorageFailed(err), "reading-list/list", "listBooks")
 
@@ -174,14 +174,14 @@ func (s *Server) RegisterRoutes() http.Handler {
 	mux.Handle("/letters", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		design := r.URL.Query().Get("design")
 		tag := r.URL.Query().Get("tag")
-		web.LettersPageHandler(w, r, *s.storage, tag, design, s.auth)
+		web.LettersPageHandler(w, r, *s.Storage, tag, design, s.auth)
 	}))
 	mux.Handle("/letter", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		letterID := r.URL.Query().Get("id")
-		web.GetLetterHandler(w, r, *s.storage, letterID, s.auth)
+		web.GetLetterHandler(w, r, *s.Storage, letterID, s.auth)
 	}))
 	mux.Handle("/letters/list", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, err := service.ListLetters(r.Context(), *s.storage, "all")
+		_, err := service.ListLetters(r.Context(), *s.Storage, "all")
 		if err != nil {
 			web.HandleError(w, r, apperrors.StorageFailed(err), "letters/list", "listLetters")
 
@@ -254,8 +254,9 @@ func (s *Server) HelloWorldHandler(w http.ResponseWriter, _ *http.Request) {
 	}
 }
 
-func (s *Server) healthHandler(w http.ResponseWriter, _ *http.Request) {
-	result := s.storage.Health()
+// HealthHandler responds with the current health status of the application.
+func (s *Server) HealthHandler(w http.ResponseWriter, _ *http.Request) {
+	result := s.Storage.Health()
 
 	resp, err := json.Marshal(result)
 	if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,7 +18,7 @@ import (
 // Server provides HTTP server configuration with storage backend.
 type Server struct {
 	port    int
-	storage *storage.Storage
+	Storage *storage.Storage
 	auth    *auth.Auth
 }
 
@@ -40,7 +40,7 @@ func NewServer() *http.Server {
 
 	NewServer := &Server{
 		port:    port,
-		storage: store,
+		Storage: store,
 		auth:    authInstance,
 	}
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -358,34 +359,85 @@ func (s *Storage) GetImage(ctx context.Context, imageName string) (string, error
 	return webPath, nil
 }
 
-// Health checks the storage connection status.
-func (s *Storage) Health() map[string]string {
-	health := make(map[string]string)
+// HealthResult holds the structured health check response.
+type HealthResult struct {
+	Status    string            `json:"status"`
+	Timestamp string            `json:"ts"`
+	Checks    map[string]string `json:"checks"`
+}
 
+// Healthy returns true when overall status is "ok".
+func (h HealthResult) Healthy() bool {
+	return h.Status == "ok"
+}
+
+// Health checks storage and database connectivity.
+func (s *Storage) Health() HealthResult {
+	checks := make(map[string]string)
+	healthy := true
+
+	checks["storage"] = s.checkStorage()
+	if checks["storage"] != "ok" {
+		healthy = false
+	}
+
+	checks["database"] = checkDatabase()
+
+	if checks["database"] != "ok" {
+		healthy = false
+	}
+
+	status := "ok"
+	if !healthy {
+		status = "degraded"
+	}
+
+	return HealthResult{
+		Status:    status,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Checks:    checks,
+	}
+}
+
+func (s *Storage) checkStorage() string {
 	if s.UseS3 {
 		_, err := s.S3Client.ListBuckets(context.Background(), &s3.ListBucketsInput{})
 		if err != nil {
-			health["status"] = "down"
-			health["message"] = fmt.Sprintf("Failed to list buckets: %v", err)
-			log.Printf("S3 connection down: %v", err) // Changed from Fatalf to allow app to survive
+			log.Printf("health: S3 connection down: %v", err)
 
-			return health
+			return fmt.Sprintf("error: %v", err)
 		}
 
-		health["status"] = "up"
-		health["message"] = "S3 storage is up and running."
-	} else {
-		_, err := os.Stat(s.BaseDir)
-		if os.IsNotExist(err) {
-			health["status"] = "down"
-			health["message"] = "Local storage directory missing"
-		} else {
-			health["status"] = "up"
-			health["message"] = "Local storage is ready."
-		}
+		return "ok"
 	}
 
-	return health
+	_, err := os.Stat(s.BaseDir)
+	if os.IsNotExist(err) {
+		return "error: local storage directory missing"
+	}
+
+	return "ok"
+}
+
+func checkDatabase() string {
+	db, err := GetDB(context.Background())
+	if err != nil {
+		return fmt.Sprintf("error: %v", err)
+	}
+
+	defer func() {
+		closeErr := db.Close()
+		if closeErr != nil {
+			log.Printf("health: failed to close database: %v", closeErr)
+		}
+	}()
+
+	err = db.PingContext(context.Background())
+	if err != nil {
+		return fmt.Sprintf("error: %v", err)
+	}
+
+	return "ok"
 }
 
 // findProjectRoot walks up the directory tree to find the project root based on go.mod.

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -263,6 +263,60 @@ func TestGetPromptContent(t *testing.T) {
 	}
 }
 
+func TestHealth(t *testing.T) {
+	t.Run("local storage ok", func(t *testing.T) {
+		dir := t.TempDir()
+
+		s := &storage.Storage{
+			UseS3:   false,
+			BaseDir: dir,
+		}
+
+		result := s.Health()
+
+		if result.Checks["storage"] != "ok" {
+			t.Errorf("expected storage ok, got %q", result.Checks["storage"])
+		}
+
+		if result.Timestamp == "" {
+			t.Error("expected timestamp to be set")
+		}
+	})
+
+	t.Run("local storage missing directory", func(t *testing.T) {
+		s := &storage.Storage{
+			UseS3:   false,
+			BaseDir: "/nonexistent/path/that/does/not/exist",
+		}
+
+		result := s.Health()
+
+		if result.Checks["storage"] == "ok" {
+			t.Error("expected storage check to report error for missing directory")
+		}
+
+		if !result.Healthy() && result.Status != "degraded" {
+			t.Errorf("expected status 'degraded', got %q", result.Status)
+		}
+	})
+
+	t.Run("healthy result reports true", func(t *testing.T) {
+		r := storage.HealthResult{Status: "ok"}
+
+		if !r.Healthy() {
+			t.Error("expected Healthy() to return true for status ok")
+		}
+	})
+
+	t.Run("degraded result reports false", func(t *testing.T) {
+		r := storage.HealthResult{Status: "degraded"}
+
+		if r.Healthy() {
+			t.Error("expected Healthy() to return false for status degraded")
+		}
+	})
+}
+
 func getYAMLDocument() *fstest.MapFile {
 	return &fstest.MapFile{
 		Data: []byte(

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -2,14 +2,19 @@ package storage_test
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	"timterests/internal/model"
 	"timterests/internal/storage"
+
+	_ "github.com/mattn/go-sqlite3"
 )
 
 func TestStorage(t *testing.T) {
@@ -263,58 +268,148 @@ func TestGetPromptContent(t *testing.T) {
 	}
 }
 
-func TestHealth(t *testing.T) {
-	t.Run("local storage ok", func(t *testing.T) {
-		dir := t.TempDir()
+func TestHealthOK(t *testing.T) {
+	setupHealthDB(t)
 
-		s := &storage.Storage{
-			UseS3:   false,
-			BaseDir: dir,
+	s := &storage.Storage{
+		UseS3:   false,
+		BaseDir: t.TempDir(),
+	}
+
+	result := s.Health()
+
+	if result.Status != "ok" {
+		t.Errorf("expected status 'ok', got %q", result.Status)
+	}
+
+	if result.Timestamp == "" {
+		t.Error("expected timestamp to be set")
+	}
+
+	_, parseErr := time.Parse(time.RFC3339, result.Timestamp)
+	if parseErr != nil {
+		t.Errorf("timestamp is not valid RFC3339: %q", result.Timestamp)
+	}
+
+	if result.Checks["storage"] != "ok" {
+		t.Errorf("expected storage check 'ok', got %q", result.Checks["storage"])
+	}
+
+	if result.Checks["database"] != "ok" {
+		t.Errorf("expected database check 'ok', got %q", result.Checks["database"])
+	}
+
+	if !result.Healthy() {
+		t.Error("expected Healthy() to return true")
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("failed to marshal health result: %v", err)
+	}
+
+	var parsed map[string]any
+
+	err = json.Unmarshal(data, &parsed)
+	if err != nil {
+		t.Fatalf("failed to unmarshal health JSON: %v", err)
+	}
+
+	for _, key := range []string{"status", "ts", "checks"} {
+		if _, ok := parsed[key]; !ok {
+			t.Errorf("expected key %q in JSON response", key)
 		}
+	}
+}
 
-		result := s.Health()
+func TestHealthDegradedDBDown(t *testing.T) {
+	// No database directory → GetDB will fail → database check returns error
+	t.Chdir(t.TempDir())
 
-		if result.Checks["storage"] != "ok" {
-			t.Errorf("expected storage ok, got %q", result.Checks["storage"])
-		}
+	s := &storage.Storage{
+		UseS3:   false,
+		BaseDir: t.TempDir(),
+	}
 
-		if result.Timestamp == "" {
-			t.Error("expected timestamp to be set")
-		}
-	})
+	result := s.Health()
 
-	t.Run("local storage missing directory", func(t *testing.T) {
-		s := &storage.Storage{
-			UseS3:   false,
-			BaseDir: "/nonexistent/path/that/does/not/exist",
-		}
+	if result.Status != "degraded" {
+		t.Errorf("expected status 'degraded', got %q", result.Status)
+	}
 
-		result := s.Health()
+	if result.Checks["storage"] != "ok" {
+		t.Errorf("expected storage 'ok', got %q", result.Checks["storage"])
+	}
 
-		if result.Checks["storage"] == "ok" {
-			t.Error("expected storage check to report error for missing directory")
-		}
+	if result.Checks["database"] == "ok" {
+		t.Error("expected database check to report error, got 'ok'")
+	}
 
-		if !result.Healthy() && result.Status != "degraded" {
-			t.Errorf("expected status 'degraded', got %q", result.Status)
-		}
-	})
+	if result.Healthy() {
+		t.Error("expected Healthy() to return false for degraded status")
+	}
+}
 
-	t.Run("healthy result reports true", func(t *testing.T) {
-		r := storage.HealthResult{Status: "ok"}
+func TestHealthDegradedStorageDown(t *testing.T) {
+	setupHealthDB(t)
 
-		if !r.Healthy() {
-			t.Error("expected Healthy() to return true for status ok")
-		}
-	})
+	s := &storage.Storage{
+		UseS3:   false,
+		BaseDir: "/nonexistent/path/that/does/not/exist",
+	}
 
-	t.Run("degraded result reports false", func(t *testing.T) {
-		r := storage.HealthResult{Status: "degraded"}
+	result := s.Health()
 
-		if r.Healthy() {
-			t.Error("expected Healthy() to return false for status degraded")
-		}
-	})
+	if result.Status != "degraded" {
+		t.Errorf("expected status 'degraded', got %q", result.Status)
+	}
+
+	if result.Checks["storage"] == "ok" {
+		t.Error("expected storage check to report error, got 'ok'")
+	}
+
+	if result.Checks["database"] != "ok" {
+		t.Errorf("expected database 'ok', got %q", result.Checks["database"])
+	}
+
+	if result.Healthy() {
+		t.Error("expected Healthy() to return false for degraded status")
+	}
+}
+
+func setupHealthDB(t *testing.T) {
+	t.Helper()
+
+	dbDir := filepath.Join(t.TempDir(), "database")
+
+	err := os.MkdirAll(dbDir, 0750)
+	if err != nil {
+		t.Fatalf("failed to create database dir: %v", err)
+	}
+
+	dbPath := filepath.Join(dbDir, "timterests.db")
+
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+
+	defer func() {
+		_ = db.Close()
+	}()
+
+	_, err = db.ExecContext(context.Background(), `CREATE TABLE IF NOT EXISTS users (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		first_name TEXT NOT NULL,
+		last_name TEXT NOT NULL,
+		email TEXT UNIQUE NOT NULL,
+		password TEXT NOT NULL
+	)`)
+	if err != nil {
+		t.Fatalf("failed to create users table: %v", err)
+	}
+
+	t.Chdir(filepath.Dir(dbDir))
 }
 
 func getYAMLDocument() *fstest.MapFile {


### PR DESCRIPTION
## Summary
- Enhance `/health` endpoint with structured JSON response: `{ status, ts, checks: { storage, database } }`
- Add database connectivity check via `GetDB` + `PingContext`
- Return HTTP 503 when any check fails (previously always returned 200)
- Add `HealthResult` type with `Healthy()` method
- Add tests for storage health checks and `HealthResult` behavior

### Response examples
**Healthy (200):**
```json
{ "status": "ok", "ts": "2026-04-19T21:01:48Z", "checks": { "database": "ok", "storage": "ok" } }
```

**Degraded (503):**
```json
{ "status": "degraded", "ts": "...", "checks": { "database": "error: ...", "storage": "ok" } }
```

## Test plan
- [x] All tests pass (`go test ./... -count=1`)
- [x] Zero lint issues (`golangci-lint run ./...`)
- [x] Verified on localhost: `curl localhost:8080/health` returns structured JSON with 200

Closes #46