### PR TITLE
Add site logo to header

### DIFF
--- a/cmd/web/assets/css/styles.css
+++ b/cmd/web/assets/css/styles.css
@@ -158,9 +158,25 @@ a:hover {
   color: var(--green-accent);
 }
 
+.banner-title-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+.banner-logo {
+  height: 36px;
+  width: auto;
+}
+
 @media (min-width: 768px) {
   .banner-title {
     font-size: 2.5rem;
+  }
+
+  .banner-logo {
+    height: 44px;
   }
 }
 

--- a/cmd/web/assets/images/logo.svg
+++ b/cmd/web/assets/images/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" fill="none">
+  <circle cx="20" cy="20" r="18" stroke="#10b981" stroke-width="3" fill="none"/>
+  <text x="20" y="26" text-anchor="middle" font-family="Georgia, serif" font-size="22" font-weight="bold" fill="#10b981">T</text>
+</svg>

--- a/cmd/web/base.templ
+++ b/cmd/web/base.templ
@@ -23,7 +23,8 @@ templ Base(activePage string) {
 	</head>
 		<body>
 			<header class="banner-header">
-				<a href="/" class="no-underline">
+				<a href="/" class="no-underline banner-title-link">
+					<img src="/assets/images/logo.svg" alt="Timterests" class="banner-logo" />
 					<h1 class="banner-title">Timterests</h1>
 				</a>
 				<div class="dark-mode-switch">


### PR DESCRIPTION
## Summary
- Adds an SVG logo (green "T" in a circle) next to the site title in the banner header
- Logo uses the existing green color scheme (`--green: #10b981`)
- Responsive sizing: 36px on mobile, 44px on desktop
- Logo and title wrapped in a flex container for proper alignment

## Test plan
- [ ] Verify logo renders on desktop viewport
- [ ] Verify logo renders on mobile viewport (hamburger nav state)
- [ ] Verify logo links to home page alongside title
- [ ] Verify logo scales correctly across breakpoints

Closes #82