### PR TITLE
fix: make logo img decorative for screen readers

### DIFF
--- a/cmd/web/base.templ
+++ b/cmd/web/base.templ
@@ -24,7 +24,7 @@ templ Base(activePage string) {
 		<body>
 			<header class="banner-header">
 				<a href="/" class="no-underline banner-title-link">
-					<img src="/assets/images/logo.svg" alt="Timterests" class="banner-logo" />
+					<img src="/assets/images/logo.svg" alt="" aria-hidden="true" class="banner-logo" />
 					<h1 class="banner-title">Timterests</h1>
 				</a>
 				<div class="dark-mode-switch">


### PR DESCRIPTION
Logo is purely decorative — the adjacent `h1` already provides the accessible name. Setting `alt=""` and `aria-hidden="true"` prevents screen readers from double-announcing "Timterests".

Follow-up to #143.