### PR TITLE
feat: add profile details to About page

### DIFF
--- a/cmd/web/about.go
+++ b/cmd/web/about.go
@@ -10,9 +10,14 @@ import (
 )
 
 type About struct {
-	Title    string `yaml:"title"`
-	Subtitle string `yaml:"subtitle"`
-	Body     string `yaml:"body"`
+	Title      string `yaml:"title"`
+	Subtitle   string `yaml:"subtitle"`
+	Body       string `yaml:"body"`
+	Name       string `yaml:"name"`
+	Specialty  string `yaml:"specialty"`
+	Location   string `yaml:"location"`
+	GitHub     string `yaml:"github"`
+	Email      string `yaml:"email"`
 }
 
 func AboutHandler(w http.ResponseWriter, r *http.Request, s storage.Storage) {

--- a/cmd/web/about.go
+++ b/cmd/web/about.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"net/http"
+	"strings"
 
 	apperrors "timterests/internal/errors"
 	"timterests/internal/storage"
@@ -51,6 +52,9 @@ func AboutHandler(w http.ResponseWriter, r *http.Request, s storage.Storage) {
 
 		return
 	}
+
+	about.GitHub = strings.TrimSpace(about.GitHub)
+	about.Email = strings.TrimSpace(about.Email)
 
 	component := AboutForm(about)
 

--- a/cmd/web/about.templ
+++ b/cmd/web/about.templ
@@ -3,9 +3,43 @@ package web
 templ AboutForm(about About) {
 	@Base("about") {
 		<div id="about-container">
-            <h1 class="category-title">{ about.Title }</h1>
-            <h2 class="category-subtitle">{ about.Subtitle }</h2>
-            @templ.Raw(about.Body)
-        </div>
+			<h1 class="category-title">{ about.Title }</h1>
+			<h2 class="category-subtitle">{ about.Subtitle }</h2>
+			if about.Name != "" || about.Specialty != "" || about.Location != "" || about.GitHub != "" || about.Email != "" {
+				<div class="about-profile">
+					if about.Name != "" {
+						<div class="about-profile-row">
+							<span class="about-profile-label"><i class="fa-solid fa-user"></i> Name</span>
+							<span class="about-profile-value">{ about.Name }</span>
+						</div>
+					}
+					if about.Specialty != "" {
+						<div class="about-profile-row">
+							<span class="about-profile-label"><i class="fa-solid fa-code"></i> Specialty</span>
+							<span class="about-profile-value">{ about.Specialty }</span>
+						</div>
+					}
+					if about.Location != "" {
+						<div class="about-profile-row">
+							<span class="about-profile-label"><i class="fa-solid fa-location-dot"></i> Location</span>
+							<span class="about-profile-value">{ about.Location }</span>
+						</div>
+					}
+					if about.GitHub != "" {
+						<div class="about-profile-row">
+							<span class="about-profile-label"><i class="fa-brands fa-github"></i> GitHub</span>
+							<a href={ templ.SafeURL("https://github.com/" + about.GitHub) } class="about-profile-link" target="_blank" rel="noopener noreferrer">{ about.GitHub }</a>
+						</div>
+					}
+					if about.Email != "" {
+						<div class="about-profile-row">
+							<span class="about-profile-label"><i class="fa-solid fa-envelope"></i> Email</span>
+							<a href={ templ.SafeURL("mailto:" + about.Email) } class="about-profile-link">{ about.Email }</a>
+						</div>
+					}
+				</div>
+			}
+			@templ.Raw(about.Body)
+		</div>
 	}
 }

--- a/cmd/web/about_test.go
+++ b/cmd/web/about_test.go
@@ -1,9 +1,11 @@
 package web_test
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"timterests/cmd/web"
 
@@ -30,6 +32,70 @@ func TestAboutHandler(t *testing.T) {
 
 		if doc.Find("title").Length() == 0 {
 			t.Error("expected title element to be rendered")
+		}
+	})
+}
+
+func TestAboutForm(t *testing.T) {
+	t.Parallel()
+
+	t.Run("profile card absent when all fields empty", func(t *testing.T) {
+		t.Parallel()
+
+		about := web.About{
+			Title:    "About",
+			Subtitle: "A subtitle",
+			Body:     "<p>Some body text.</p>",
+		}
+
+		var buf bytes.Buffer
+
+		err := web.AboutForm(about).Render(context.Background(), &buf)
+		if err != nil {
+			t.Fatalf("render failed: %v", err)
+		}
+
+		if strings.Contains(buf.String(), "about-profile") {
+			t.Error("expected profile card to be absent when all profile fields are empty")
+		}
+	})
+
+	t.Run("profile card renders all populated fields", func(t *testing.T) {
+		t.Parallel()
+
+		about := web.About{
+			Title:     "About",
+			Subtitle:  "A subtitle",
+			Body:      "<p>Some body text.</p>",
+			Name:      "Tim Scott",
+			Specialty: "Software Engineering",
+			Location:  "United States",
+			GitHub:    "TheTimbob",
+			Email:     "tscott1275@gmail.com",
+		}
+
+		var buf bytes.Buffer
+
+		err := web.AboutForm(about).Render(context.Background(), &buf)
+		if err != nil {
+			t.Fatalf("render failed: %v", err)
+		}
+
+		html := buf.String()
+
+		for _, want := range []string{
+			"about-profile",
+			"Tim Scott",
+			"Software Engineering",
+			"United States",
+			"TheTimbob",
+			"tscott1275@gmail.com",
+			"https://github.com/TheTimbob",
+			"mailto:tscott1275@gmail.com",
+		} {
+			if !strings.Contains(html, want) {
+				t.Errorf("expected rendered output to contain %q", want)
+			}
 		}
 	})
 }

--- a/cmd/web/assets/css/styles.css
+++ b/cmd/web/assets/css/styles.css
@@ -187,6 +187,59 @@ a:hover {
   font-weight: 500;
 }
 
+/* About profile */
+.about-profile {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 1.25rem 0;
+  padding: 1.25rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background-color: var(--bg-light);
+  max-width: 480px;
+}
+
+.dark .about-profile {
+  background-color: var(--bg-dark-accent);
+  border-color: var(--border);
+}
+
+.about-profile-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.about-profile-label {
+  width: 110px;
+  flex-shrink: 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.about-profile-value {
+  color: var(--text-light);
+}
+
+.dark .about-profile-value {
+  color: var(--text-dark);
+}
+
+.about-profile-link {
+  color: var(--green);
+  text-decoration: none;
+}
+
+.about-profile-link:hover {
+  color: var(--green-accent);
+  text-decoration: underline;
+}
+
 .banner-footer {
   background-color: var(--bg-light);
   padding: 0.75rem;

--- a/cmd/web/assets/css/styles.css
+++ b/cmd/web/assets/css/styles.css
@@ -202,7 +202,7 @@ a:hover {
 
 .dark .about-profile {
   background-color: var(--bg-dark-accent);
-  border-color: var(--border);
+  border-color: var(--bg-dark-accent);
 }
 
 .about-profile-row {


### PR DESCRIPTION
## Summary
- Adds `Name`, `Specialty`, `Location`, `GitHub`, and `Email` fields to the `About` struct and YAML schema
- Template renders them as a styled profile card with Font Awesome icons
- Card is conditionally rendered — hidden when all five fields are empty (backwards compatible)
- CSS uses the existing green color scheme and respects dark mode

## Test plan
- [ ] Verify profile card renders on the About page at `/about`
- [ ] Verify all five fields display correctly
- [ ] Verify GitHub and Email fields render as clickable links
- [ ] Verify dark mode styling
- [ ] Verify mobile layout

Closes #111