### PR TITLE
feat: read About body from paired .md file

### DIFF
--- a/cmd/web/about.go
+++ b/cmd/web/about.go
@@ -39,7 +39,15 @@ func AboutHandler(w http.ResponseWriter, r *http.Request, s storage.Storage) {
 		return
 	}
 
-	key := aws.ToString(aboutFile[0].Key)
+	var key string
+	for _, obj := range aboutFile {
+		k := aws.ToString(obj.Key)
+		if strings.HasSuffix(k, ".yaml") {
+			key = k
+			break
+		}
+	}
+
 	if key == "" {
 		HandleError(w, r, apperrors.NotFound(nil), "AboutHandler", "getKey")
 
@@ -53,6 +61,14 @@ func AboutHandler(w http.ResponseWriter, r *http.Request, s storage.Storage) {
 		return
 	}
 
+	body, err := s.GetDocumentBody(r.Context(), key)
+	if err != nil {
+		HandleError(w, r, apperrors.StorageFailed(err), "AboutHandler", "getDocumentBody")
+
+		return
+	}
+
+	about.Body = body
 	about.GitHub = strings.TrimSpace(about.GitHub)
 	about.Email = strings.TrimSpace(about.Email)
 

--- a/cmd/web/about.go
+++ b/cmd/web/about.go
@@ -40,10 +40,12 @@ func AboutHandler(w http.ResponseWriter, r *http.Request, s storage.Storage) {
 	}
 
 	var key string
+
 	for _, obj := range aboutFile {
 		k := aws.ToString(obj.Key)
 		if strings.HasSuffix(k, ".yaml") {
 			key = k
+
 			break
 		}
 	}

--- a/storage/testdata/about/about.md
+++ b/storage/testdata/about/about.md
@@ -1,0 +1,3 @@
+# About Timterests
+
+This is the about page content.

--- a/storage/testdata/about/about.yaml
+++ b/storage/testdata/about/about.yaml
@@ -1,3 +1,2 @@
 title: About Timterests
 subtitle: A personal blog
-body: This is the about page content.


### PR DESCRIPTION
## Summary
- `AboutHandler` now calls `GetDocumentBody` to read body content from `about-me.md` instead of inline YAML
- Filters `ListObjects` results to `.yaml` keys so the handler isn't confused by the paired `.md` in the same directory
- Aligns About with the split-doc pattern used by articles, letters, and projects
- Testdata updated: `about.yaml` is metadata-only, `about.md` holds the body

## Why
`about-me.md` existed in timterests-docs but was never read by the handler. Any edits to the `.md` file would silently have no effect — a quiet bug. This wires it up correctly and eliminates the inconsistency.

## Test plan
- [ ] Verify `/about` renders body content from `.md` on localhost
- [ ] Verify profile card fields (name, specialty, location, GitHub, email) still render from `.yaml`
- [ ] All tests pass