### PR TITLE
feat: restore About page tab UI with bio, experience, education, skills

### DIFF
--- a/cmd/web/about.go
+++ b/cmd/web/about.go
@@ -8,17 +8,44 @@ import (
 	"timterests/internal/storage"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/a-h/templ"
 )
 
+type Experience struct {
+	Company     string `yaml:"company"`
+	Role        string `yaml:"role"`
+	StartDate   string `yaml:"start_date"`
+	EndDate     string `yaml:"end_date"`
+	Description string `yaml:"description"`
+	Location    string `yaml:"location"`
+}
+
+type Education struct {
+	Institution string `yaml:"institution"`
+	Degree      string `yaml:"degree"`
+	StartDate   string `yaml:"start_date"`
+	EndDate     string `yaml:"end_date"`
+	Description string `yaml:"description"`
+	Location    string `yaml:"location"`
+}
+
+type Skill struct {
+	Name  string   `yaml:"name"`
+	Items []string `yaml:"items"`
+}
+
 type About struct {
-	Title      string `yaml:"title"`
-	Subtitle   string `yaml:"subtitle"`
-	Body       string `yaml:"body"`
-	Name       string `yaml:"name"`
-	Specialty  string `yaml:"specialty"`
-	Location   string `yaml:"location"`
-	GitHub     string `yaml:"github"`
-	Email      string `yaml:"email"`
+	Title      string       `yaml:"title"`
+	Subtitle   string       `yaml:"subtitle"`
+	Body       string       `yaml:"-"`
+	Name       string       `yaml:"name"`
+	Specialty  string       `yaml:"specialty"`
+	Location   string       `yaml:"location"`
+	GitHub     string       `yaml:"github"`
+	Email      string       `yaml:"email"`
+	Experience []Experience `yaml:"experience"`
+	Education  []Education  `yaml:"education"`
+	Skills     []Skill      `yaml:"skills"`
 }
 
 func AboutHandler(w http.ResponseWriter, r *http.Request, s storage.Storage) {
@@ -39,7 +66,17 @@ func AboutHandler(w http.ResponseWriter, r *http.Request, s storage.Storage) {
 		return
 	}
 
-	key := aws.ToString(aboutFile[0].Key)
+	var key string
+
+	for _, obj := range aboutFile {
+		k := aws.ToString(obj.Key)
+		if strings.HasSuffix(k, ".yaml") {
+			key = k
+
+			break
+		}
+	}
+
 	if key == "" {
 		HandleError(w, r, apperrors.NotFound(nil), "AboutHandler", "getKey")
 
@@ -53,10 +90,31 @@ func AboutHandler(w http.ResponseWriter, r *http.Request, s storage.Storage) {
 		return
 	}
 
+	body, err := s.GetDocumentBody(r.Context(), key)
+	if err != nil {
+		HandleError(w, r, apperrors.StorageFailed(err), "AboutHandler", "getDocumentBody")
+
+		return
+	}
+
+	about.Body = body
 	about.GitHub = strings.TrimSpace(about.GitHub)
 	about.Email = strings.TrimSpace(about.Email)
 
-	component := AboutForm(about)
+	var component templ.Component
+
+	switch r.URL.Query().Get("tab") {
+	case "bio":
+		component = BioTab(about)
+	case "education":
+		component = EducationTab(about.Education)
+	case "work":
+		component = ExperienceTab(about.Experience)
+	case "skills":
+		component = SkillsTab(about.Skills)
+	default:
+		component = AboutForm(about)
+	}
 
 	err = renderHTML(w, r, http.StatusOK, component)
 	if err != nil {

--- a/cmd/web/about.go
+++ b/cmd/web/about.go
@@ -14,8 +14,8 @@ import (
 type Experience struct {
 	Company     string `yaml:"company"`
 	Role        string `yaml:"role"`
-	StartDate   string `yaml:"start_date"`
-	EndDate     string `yaml:"end_date"`
+	StartDate   string `yaml:"startDate"`
+	EndDate     string `yaml:"endDate"`
 	Description string `yaml:"description"`
 	Location    string `yaml:"location"`
 }
@@ -23,8 +23,8 @@ type Experience struct {
 type Education struct {
 	Institution string `yaml:"institution"`
 	Degree      string `yaml:"degree"`
-	StartDate   string `yaml:"start_date"`
-	EndDate     string `yaml:"end_date"`
+	StartDate   string `yaml:"startDate"`
+	EndDate     string `yaml:"endDate"`
 	Description string `yaml:"description"`
 	Location    string `yaml:"location"`
 }

--- a/cmd/web/about.templ
+++ b/cmd/web/about.templ
@@ -2,44 +2,112 @@ package web
 
 templ AboutForm(about About) {
 	@Base("about") {
-		<div id="about-container">
+		<div id="about-container" class="animate-fade-in">
 			<h1 class="category-title">{ about.Title }</h1>
-			<h2 class="category-subtitle">{ about.Subtitle }</h2>
-			if about.Name != "" || about.Specialty != "" || about.Location != "" || about.GitHub != "" || about.Email != "" {
-				<div class="about-profile">
-					if about.Name != "" {
-						<div class="about-profile-row">
-							<span class="about-profile-label"><i class="fa-solid fa-user"></i> Name</span>
-							<span class="about-profile-value">{ about.Name }</span>
-						</div>
-					}
-					if about.Specialty != "" {
-						<div class="about-profile-row">
-							<span class="about-profile-label"><i class="fa-solid fa-code"></i> Specialty</span>
-							<span class="about-profile-value">{ about.Specialty }</span>
-						</div>
-					}
-					if about.Location != "" {
-						<div class="about-profile-row">
-							<span class="about-profile-label"><i class="fa-solid fa-location-dot"></i> Location</span>
-							<span class="about-profile-value">{ about.Location }</span>
-						</div>
-					}
-					if about.GitHub != "" {
-						<div class="about-profile-row">
-							<span class="about-profile-label"><i class="fa-brands fa-github"></i> GitHub</span>
-							<a href={ templ.SafeURL("https://github.com/" + about.GitHub) } class="about-profile-link" target="_blank" rel="noopener noreferrer">{ about.GitHub }</a>
-						</div>
-					}
-					if about.Email != "" {
-						<div class="about-profile-row">
-							<span class="about-profile-label"><i class="fa-solid fa-envelope"></i> Email</span>
-							<a href={ templ.SafeURL("mailto:" + about.Email) } class="about-profile-link">{ about.Email }</a>
-						</div>
-					}
-				</div>
-			}
-			@templ.Raw(about.Body)
+			<div class="about-tabs">
+				<button class="tab-btn active" hx-get="/about?tab=bio" hx-target=".tab-content" hx-swap="innerHTML" onclick="setActiveTab(this)">Bio</button>
+				<button class="tab-btn" hx-get="/about?tab=education" hx-target=".tab-content" hx-swap="innerHTML" onclick="setActiveTab(this)">Education</button>
+				<button class="tab-btn" hx-get="/about?tab=work" hx-target=".tab-content" hx-swap="innerHTML" onclick="setActiveTab(this)">Experience</button>
+				<button class="tab-btn" hx-get="/about?tab=skills" hx-target=".tab-content" hx-swap="innerHTML" onclick="setActiveTab(this)">Skills</button>
+			</div>
+			<div class="tab-content">
+				@BioTab(about)
+			</div>
 		</div>
 	}
+}
+
+templ BioTab(about About) {
+	<div class="about-profile">
+		if about.Name != "" {
+			<div class="about-profile-row">
+				<span class="about-profile-label"><i class="fa-solid fa-user"></i> Name</span>
+				<span class="about-profile-value">{ about.Name }</span>
+			</div>
+		}
+		if about.Specialty != "" {
+			<div class="about-profile-row">
+				<span class="about-profile-label"><i class="fa-solid fa-code"></i> Specialty</span>
+				<span class="about-profile-value">{ about.Specialty }</span>
+			</div>
+		}
+		if about.Location != "" {
+			<div class="about-profile-row">
+				<span class="about-profile-label"><i class="fa-solid fa-location-dot"></i> Location</span>
+				<span class="about-profile-value">{ about.Location }</span>
+			</div>
+		}
+		if about.GitHub != "" {
+			<div class="about-profile-row">
+				<span class="about-profile-label"><i class="fa-brands fa-github"></i> GitHub</span>
+				<a href={ templ.SafeURL("https://github.com/" + about.GitHub) } class="about-profile-link" target="_blank" rel="noopener noreferrer">{ about.GitHub }</a>
+			</div>
+		}
+		if about.Email != "" {
+			<div class="about-profile-row">
+				<span class="about-profile-label"><i class="fa-solid fa-envelope"></i> Email</span>
+				<a href={ templ.SafeURL("mailto:" + about.Email) } class="about-profile-link">{ about.Email }</a>
+			</div>
+		}
+	</div>
+	<hr class="about-divider"/>
+	@templ.Raw(about.Body)
+}
+
+templ ExperienceTab(jobs []Experience) {
+	<div id="work" class="timeline-container">
+		for _, job := range jobs {
+			<div class="timeline-item">
+				<div class="timeline-marker"></div>
+				<div class="timeline-date">{ job.StartDate } - { job.EndDate }</div>
+				<h3 class="timeline-title">{ job.Role }</h3>
+				<div class="timeline-subtitle">{ job.Company }</div>
+				if job.Location != "" {
+					<div class="timeline-location">{ job.Location }</div>
+				}
+				<div class="timeline-description">
+					@templ.Raw(job.Description)
+				</div>
+			</div>
+		}
+	</div>
+}
+
+templ EducationTab(education []Education) {
+	<div id="education" class="timeline-container">
+		for _, edu := range education {
+			<div class="timeline-item">
+				<div class="timeline-marker"></div>
+				<div class="timeline-date">{ edu.StartDate } - { edu.EndDate }</div>
+				<h3 class="timeline-title">{ edu.Degree }</h3>
+				<div class="timeline-subtitle">{ edu.Institution }</div>
+				if edu.Location != "" {
+					<div class="timeline-location">{ edu.Location }</div>
+				}
+				<div class="timeline-description">
+					@templ.Raw(edu.Description)
+				</div>
+			</div>
+		}
+	</div>
+}
+
+templ SkillsTab(skills []Skill) {
+	<div id="skills" class="skills-container">
+		for _, skill := range skills {
+			<div class="skill-item">
+				<div class="skill-header" onclick="toggleSkill(this)">
+					<span>{ skill.Name }</span>
+					<i class="fas fa-chevron-down"></i>
+				</div>
+				<div class="skill-content">
+					<div class="skill-list">
+						for _, item := range skill.Items {
+							<span class="skill-tag">{ item }</span>
+						}
+					</div>
+				</div>
+			</div>
+		}
+	</div>
 }

--- a/cmd/web/about_test.go
+++ b/cmd/web/about_test.go
@@ -33,39 +33,56 @@ func TestAboutHandler(t *testing.T) {
 		if doc.Find("title").Length() == 0 {
 			t.Error("expected title element to be rendered")
 		}
+
+		if doc.Find(".about-tabs").Length() == 0 {
+			t.Error("expected tab nav to be rendered")
+		}
+	})
+
+	t.Run("returns bio tab partial for HTMX request", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/about?tab=bio", nil)
+		rec := httptest.NewRecorder()
+
+		web.AboutHandler(rec, req, *s)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+
+		if !strings.Contains(rec.Body.String(), "about-profile") {
+			t.Error("expected bio tab to contain profile card")
+		}
 	})
 }
 
 func TestAboutForm(t *testing.T) {
 	t.Parallel()
 
-	t.Run("profile card absent when all fields empty", func(t *testing.T) {
+	t.Run("profile card absent in bio tab when all fields empty", func(t *testing.T) {
 		t.Parallel()
 
 		about := web.About{
-			Title:    "About",
-			Subtitle: "A subtitle",
-			Body:     "<p>Some body text.</p>",
+			Title: "About",
+			Body:  "<p>Some body text.</p>",
 		}
 
 		var buf bytes.Buffer
 
-		err := web.AboutForm(about).Render(context.Background(), &buf)
+		err := web.BioTab(about).Render(context.Background(), &buf)
 		if err != nil {
 			t.Fatalf("render failed: %v", err)
 		}
 
-		if strings.Contains(buf.String(), "about-profile") {
-			t.Error("expected profile card to be absent when all profile fields are empty")
+		if strings.Contains(buf.String(), "about-profile-row") {
+			t.Error("expected no profile rows when all fields are empty")
 		}
 	})
 
-	t.Run("profile card renders all populated fields", func(t *testing.T) {
+	t.Run("bio tab renders populated profile fields", func(t *testing.T) {
 		t.Parallel()
 
 		about := web.About{
 			Title:     "About",
-			Subtitle:  "A subtitle",
 			Body:      "<p>Some body text.</p>",
 			Name:      "Tim Scott",
 			Specialty: "Software Engineering",
@@ -76,7 +93,7 @@ func TestAboutForm(t *testing.T) {
 
 		var buf bytes.Buffer
 
-		err := web.AboutForm(about).Render(context.Background(), &buf)
+		err := web.BioTab(about).Render(context.Background(), &buf)
 		if err != nil {
 			t.Fatalf("render failed: %v", err)
 		}
@@ -84,7 +101,6 @@ func TestAboutForm(t *testing.T) {
 		html := buf.String()
 
 		for _, want := range []string{
-			"about-profile",
 			"Tim Scott",
 			"Software Engineering",
 			"United States",
@@ -95,6 +111,58 @@ func TestAboutForm(t *testing.T) {
 		} {
 			if !strings.Contains(html, want) {
 				t.Errorf("expected rendered output to contain %q", want)
+			}
+		}
+	})
+
+	t.Run("experience tab renders timeline items", func(t *testing.T) {
+		t.Parallel()
+
+		jobs := []web.Experience{
+			{
+				Company:   "Acme Corp",
+				Role:      "Software Engineer",
+				StartDate: "2020",
+				EndDate:   "Present",
+				Location:  "Remote",
+			},
+		}
+
+		var buf bytes.Buffer
+
+		err := web.ExperienceTab(jobs).Render(context.Background(), &buf)
+		if err != nil {
+			t.Fatalf("render failed: %v", err)
+		}
+
+		html := buf.String()
+
+		for _, want := range []string{"Acme Corp", "Software Engineer", "2020", "Remote"} {
+			if !strings.Contains(html, want) {
+				t.Errorf("expected experience tab to contain %q", want)
+			}
+		}
+	})
+
+	t.Run("skills tab renders skill tags", func(t *testing.T) {
+		t.Parallel()
+
+		skills := []web.Skill{
+			{Name: "Backend", Items: []string{"Go", "Python", "SQL"}},
+		}
+
+		var buf bytes.Buffer
+
+		err := web.SkillsTab(skills).Render(context.Background(), &buf)
+		if err != nil {
+			t.Fatalf("render failed: %v", err)
+		}
+
+		html := buf.String()
+
+		for _, want := range []string{"Backend", "Go", "Python", "SQL", "skill-tag"} {
+			if !strings.Contains(html, want) {
+				t.Errorf("expected skills tab to contain %q", want)
 			}
 		}
 	})

--- a/cmd/web/assets/css/styles.css
+++ b/cmd/web/assets/css/styles.css
@@ -246,6 +246,188 @@ a:hover {
   text-decoration: underline;
 }
 
+.about-divider {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 1.25rem 0;
+}
+
+.dark .about-divider {
+  border-top-color: var(--bg-dark-accent);
+}
+
+/* About tabs */
+.about-tabs {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 2rem;
+  gap: 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.dark .about-tabs {
+  border-color: var(--bg-dark-accent);
+}
+
+.tab-btn {
+  background: none;
+  border: none;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-bottom: 3px solid transparent;
+  margin-bottom: -1px;
+}
+
+.tab-btn.active {
+  color: var(--green);
+  border-bottom-color: var(--green);
+}
+
+.dark .tab-btn.active {
+  color: var(--green-accent);
+  border-bottom-color: var(--green-accent);
+}
+
+/* Timeline (experience & education) */
+.timeline-container {
+  padding-left: 2rem;
+  border-left: 2px solid var(--border);
+  margin: 1rem 0 0 0.5rem;
+}
+
+.dark .timeline-container {
+  border-left-color: var(--bg-dark-accent);
+}
+
+.timeline-item {
+  position: relative;
+  margin-bottom: 2rem;
+}
+
+.timeline-marker {
+  position: absolute;
+  left: -2.4rem;
+  top: 0;
+  width: 0.75rem;
+  height: 0.75rem;
+  background-color: var(--green);
+  border-radius: 50%;
+  border: 3px solid var(--bg-light);
+}
+
+.dark .timeline-marker {
+  border-color: var(--bg-dark-transparent);
+}
+
+.timeline-date {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.timeline-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-light);
+  margin: 0.25rem 0;
+}
+
+.dark .timeline-title {
+  color: var(--text-dark);
+}
+
+.timeline-subtitle {
+  color: var(--green);
+  font-weight: 600;
+}
+
+.dark .timeline-subtitle {
+  color: var(--green-accent);
+}
+
+.timeline-location {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.timeline-description {
+  color: var(--text-light);
+  margin-top: 0.5rem;
+}
+
+.dark .timeline-description {
+  color: var(--text-dark);
+}
+
+/* Skills accordion */
+.skills-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.skill-item {
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background-color: white;
+}
+
+.dark .skill-item {
+  background-color: var(--bg-dark-accent);
+  border-color: var(--bg-dark-accent);
+}
+
+.skill-header {
+  padding: 1rem;
+  display: flex;
+  justify-content: space-between;
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--text-light);
+}
+
+.dark .skill-header {
+  color: var(--text-dark);
+}
+
+.skill-header i {
+  transition: transform 0.3s;
+  color: var(--green);
+}
+
+.skill-item.active .skill-header i {
+  transform: rotate(180deg);
+}
+
+.skill-content {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s;
+}
+
+.skill-list {
+  padding: 0 1rem 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.skill-tag {
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.875rem;
+  background-color: var(--green-tag);
+  color: var(--text-muted);
+}
+
+.dark .skill-tag {
+  background-color: var(--green-dark);
+  color: var(--text-dark);
+}
+
 .banner-footer {
   background-color: var(--bg-light);
   padding: 0.75rem;

--- a/cmd/web/assets/js/buttons.js
+++ b/cmd/web/assets/js/buttons.js
@@ -2,3 +2,19 @@ function handleViewChange(button) {
     button.parentElement.querySelectorAll('.view-btn').forEach(e => e.classList.remove('active'));
     button.classList.add('active');
 }
+
+function setActiveTab(button) {
+    document.querySelectorAll('.tab-btn').forEach(btn => btn.classList.remove('active'));
+    button.classList.add('active');
+}
+
+function toggleSkill(header) {
+    const item = header.parentElement;
+    const content = header.nextElementSibling;
+    item.classList.toggle('active');
+    if (content.style.maxHeight) {
+        content.style.maxHeight = null;
+    } else {
+        content.style.maxHeight = content.scrollHeight + 'px';
+    }
+}

--- a/storage/testdata/about/about.md
+++ b/storage/testdata/about/about.md
@@ -1,0 +1,3 @@
+# About
+
+This is the about page content.

--- a/storage/testdata/about/about.yaml
+++ b/storage/testdata/about/about.yaml
@@ -1,3 +1,10 @@
 title: About Timterests
 subtitle: A personal blog
-body: This is the about page content.
+name: Test User
+specialty: Software Engineering
+location: United States
+github: testuser
+email: test@example.com
+experience: []
+education: []
+skills: []


### PR DESCRIPTION
## Summary
Restores the full tabbed About page that was accidentally regressed in PR #111.

## Data format
- `about-me.yaml` — all structured data: metadata fields + `experience[]`, `education[]`, `skills[]` arrays
- `about-me.md` — bio prose (markdown, rendered to HTML)

This matches the split-doc pattern used by all other document types. Handler reads both via `GetPreparedFile` + `GetDocumentBody`.

## What's restored
- HTMX tab switcher: Bio | Education | Experience | Skills
- Timeline components for Experience and Education (date range, role, company, location, description)
- Skills accordion with expandable skill groups and tags
- `setActiveTab` and `toggleSkill` JS functions in `buttons.js`
- All tab/timeline/skills CSS

## What's needed from timterests-docs
`about-me.yaml` needs `experience[]`, `education[]`, and `skills[]` populated — see schema below. Until Wanda adds that data, the tabs render empty (by design).

```yaml
experience:
  - company: Acme Corp
    role: Software Engineer
    start_date: "2022"
    end_date: Present
    location: Remote
    description: "What you did here."

education:
  - institution: University Name
    degree: B.S. Computer Science
    start_date: "2018"
    end_date: "2022"
    location: City, State
    description: ""

skills:
  - name: Backend
    items: [Go, Python, SQL]
  - name: Infrastructure
    items: [Docker, AWS, GitHub Actions]
```

## Test plan
- [ ] Bio tab renders profile card + bio prose
- [ ] Experience tab renders timeline (once data is populated in YAML)
- [ ] Education tab renders timeline (once data is populated in YAML)
- [ ] Skills tab renders accordion (once data is populated in YAML)
- [ ] Tab switching works via HTMX
- [ ] All tests pass

Closes #111