### PR TITLE
fix: remove bio card, redesign skills layout, reorder tabs

### DIFF
--- a/cmd/web/about.go
+++ b/cmd/web/about.go
@@ -30,8 +30,9 @@ type Education struct {
 }
 
 type Skill struct {
-	Name  string   `yaml:"name"`
-	Items []string `yaml:"items"`
+	Name        string   `yaml:"name"`
+	Items       []string `yaml:"items"`
+	Description string   `yaml:"description"`
 }
 
 type About struct {

--- a/cmd/web/about.templ
+++ b/cmd/web/about.templ
@@ -6,9 +6,9 @@ templ AboutForm(about About) {
 			<h1 class="category-title">{ about.Title }</h1>
 			<div class="about-tabs">
 				<button class="tab-btn active" hx-get="/about?tab=bio" hx-target=".tab-content" hx-swap="innerHTML" onclick="setActiveTab(this)">Bio</button>
-				<button class="tab-btn" hx-get="/about?tab=education" hx-target=".tab-content" hx-swap="innerHTML" onclick="setActiveTab(this)">Education</button>
-				<button class="tab-btn" hx-get="/about?tab=work" hx-target=".tab-content" hx-swap="innerHTML" onclick="setActiveTab(this)">Experience</button>
 				<button class="tab-btn" hx-get="/about?tab=skills" hx-target=".tab-content" hx-swap="innerHTML" onclick="setActiveTab(this)">Skills</button>
+				<button class="tab-btn" hx-get="/about?tab=work" hx-target=".tab-content" hx-swap="innerHTML" onclick="setActiveTab(this)">Experience</button>
+				<button class="tab-btn" hx-get="/about?tab=education" hx-target=".tab-content" hx-swap="innerHTML" onclick="setActiveTab(this)">Education</button>
 			</div>
 			<div class="tab-content">
 				@BioTab(about)
@@ -54,6 +54,29 @@ templ BioTab(about About) {
 	@templ.Raw(about.Body)
 }
 
+templ SkillsTab(skills []Skill) {
+	<div id="skills" class="skills-container">
+		for i, skill := range skills {
+			<div class="skill-section">
+				<h3 class="skill-section-title">{ skill.Name }</h3>
+				if len(skill.Items) > 0 {
+					<div class="skill-tags">
+						for _, item := range skill.Items {
+							<span class="skill-tag">{ item }</span>
+						}
+					</div>
+				}
+				if skill.Description != "" {
+					<p class="skill-description">{ skill.Description }</p>
+				}
+			</div>
+			if i < len(skills)-1 {
+				<hr class="skill-divider"/>
+			}
+		}
+	</div>
+}
+
 templ ExperienceTab(jobs []Experience) {
 	<div id="work" class="timeline-container">
 		for _, job := range jobs {
@@ -65,9 +88,11 @@ templ ExperienceTab(jobs []Experience) {
 				if job.Location != "" {
 					<div class="timeline-location">{ job.Location }</div>
 				}
-				<div class="timeline-description">
-					@templ.Raw(job.Description)
-				</div>
+				if job.Description != "" {
+					<div class="timeline-description">
+						@templ.Raw(job.Description)
+					</div>
+				}
 			</div>
 		}
 	</div>
@@ -84,29 +109,11 @@ templ EducationTab(education []Education) {
 				if edu.Location != "" {
 					<div class="timeline-location">{ edu.Location }</div>
 				}
-				<div class="timeline-description">
-					@templ.Raw(edu.Description)
-				</div>
-			</div>
-		}
-	</div>
-}
-
-templ SkillsTab(skills []Skill) {
-	<div id="skills" class="skills-container">
-		for _, skill := range skills {
-			<div class="skill-item">
-				<div class="skill-header" onclick="toggleSkill(this)">
-					<span>{ skill.Name }</span>
-					<i class="fas fa-chevron-down"></i>
-				</div>
-				<div class="skill-content">
-					<div class="skill-list">
-						for _, item := range skill.Items {
-							<span class="skill-tag">{ item }</span>
-						}
+				if edu.Description != "" {
+					<div class="timeline-description">
+						@templ.Raw(edu.Description)
 					</div>
-				</div>
+				}
 			</div>
 		}
 	</div>

--- a/cmd/web/about_test.go
+++ b/cmd/web/about_test.go
@@ -144,11 +144,15 @@ func TestAboutForm(t *testing.T) {
 		}
 	})
 
-	t.Run("skills tab renders skill tags", func(t *testing.T) {
+	t.Run("skills tab renders sections with tags and description", func(t *testing.T) {
 		t.Parallel()
 
 		skills := []web.Skill{
-			{Name: "Backend", Items: []string{"Go", "Python", "SQL"}},
+			{
+				Name:        "Backend",
+				Items:       []string{"Go", "Python", "SQL"},
+				Description: "Five years building backend systems.",
+			},
 		}
 
 		var buf bytes.Buffer
@@ -160,7 +164,7 @@ func TestAboutForm(t *testing.T) {
 
 		html := buf.String()
 
-		for _, want := range []string{"Backend", "Go", "Python", "SQL", "skill-tag"} {
+		for _, want := range []string{"Backend", "Go", "Python", "SQL", "skill-section-title", "Five years"} {
 			if !strings.Contains(html, want) {
 				t.Errorf("expected skills tab to contain %q", want)
 			}

--- a/cmd/web/assets/css/styles.css
+++ b/cmd/web/assets/css/styles.css
@@ -356,62 +356,32 @@ a:hover {
   color: var(--text-dark);
 }
 
-/* Skills accordion */
+/* Skills */
 .skills-container {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
 }
 
-.skill-item {
-  border: 1px solid var(--border);
-  border-radius: 0.5rem;
-  background-color: var(--bg-light);
-  transition: border-color 0.15s;
+.skill-section {
+  padding: 1.5rem 0;
 }
 
-.skill-item:hover {
-  border-color: var(--green);
-}
-
-.dark .skill-item {
-  background-color: var(--bg-dark-accent);
-  border-color: var(--bg-dark-accent);
-}
-
-.skill-header {
-  padding: 1rem;
-  display: flex;
-  justify-content: space-between;
-  cursor: pointer;
-  font-weight: 600;
+.skill-section-title {
+  font-size: 1.125rem;
+  font-weight: 700;
   color: var(--text-light);
+  margin: 0 0 0.75rem;
 }
 
-.dark .skill-header {
+.dark .skill-section-title {
   color: var(--text-dark);
 }
 
-.skill-header i {
-  transition: transform 0.3s;
-  color: var(--green);
-}
-
-.skill-item.active .skill-header i {
-  transform: rotate(180deg);
-}
-
-.skill-content {
-  max-height: 0;
-  overflow: hidden;
-  transition: max-height 0.3s;
-}
-
-.skill-list {
-  padding: 0 1rem 1rem;
+.skill-tags {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+  margin-bottom: 0.75rem;
 }
 
 .skill-tag {
@@ -425,6 +395,27 @@ a:hover {
 .dark .skill-tag {
   background-color: var(--green-dark);
   color: var(--text-dark);
+}
+
+.skill-description {
+  font-size: 0.9375rem;
+  line-height: 1.65;
+  color: var(--text-light);
+  margin: 0;
+}
+
+.dark .skill-description {
+  color: var(--text-dark);
+}
+
+.skill-divider {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 0;
+}
+
+.dark .skill-divider {
+  border-top-color: var(--bg-dark-accent);
 }
 
 .banner-footer {

--- a/cmd/web/assets/css/styles.css
+++ b/cmd/web/assets/css/styles.css
@@ -197,18 +197,8 @@ a:hover {
 .about-profile {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.6rem;
   margin: 1.25rem 0;
-  padding: 1.25rem;
-  border: 1px solid var(--border);
-  border-radius: 0.5rem;
-  background-color: var(--bg-light);
-  max-width: 480px;
-}
-
-.dark .about-profile {
-  background-color: var(--bg-dark-accent);
-  border-color: var(--bg-dark-accent);
 }
 
 .about-profile-row {
@@ -273,11 +263,13 @@ a:hover {
   background: none;
   border: none;
   padding: 0.75rem 1rem;
+  font-size: 0.9375rem;
   font-weight: 600;
   color: var(--text-muted);
   cursor: pointer;
   border-bottom: 3px solid transparent;
   margin-bottom: -1px;
+  transition: color 0.15s;
 }
 
 .tab-btn.active {
@@ -355,6 +347,8 @@ a:hover {
 
 .timeline-description {
   color: var(--text-light);
+  font-size: 0.9375rem;
+  line-height: 1.6;
   margin-top: 0.5rem;
 }
 
@@ -372,7 +366,12 @@ a:hover {
 .skill-item {
   border: 1px solid var(--border);
   border-radius: 0.5rem;
-  background-color: white;
+  background-color: var(--bg-light);
+  transition: border-color 0.15s;
+}
+
+.skill-item:hover {
+  border-color: var(--green);
 }
 
 .dark .skill-item {


### PR DESCRIPTION
Follow-up to #148. Two commits that landed after the merge:

- **Remove card styling from bio profile** — plain list layout, no background/border/radius
- **Redesign skills tab** — static sections with heading + tag summary + description paragraph, no accordion. Dividers between groups.
- **Reorder tabs** — Bio | Skills | Experience | Education
- **Polish** — tab button transitions, timeline description line-height, skill item hover state

Closes #111