### PR TITLE
fix: remove dead toggleSkill after accordion removal

### DIFF
--- a/cmd/web/assets/js/buttons.js
+++ b/cmd/web/assets/js/buttons.js
@@ -7,14 +7,3 @@ function setActiveTab(button) {
     document.querySelectorAll('.tab-btn').forEach(btn => btn.classList.remove('active'));
     button.classList.add('active');
 }
-
-function toggleSkill(header) {
-    const item = header.parentElement;
-    const content = header.nextElementSibling;
-    item.classList.toggle('active');
-    if (content.style.maxHeight) {
-        content.style.maxHeight = null;
-    } else {
-        content.style.maxHeight = content.scrollHeight + 'px';
-    }
-}


### PR DESCRIPTION
Copilot flagged this in #149 — the skills accordion was removed but `toggleSkill()` in `buttons.js` was left behind. Removes the dead function.

One file, 11 lines deleted.