### PR TITLE
feat: remove read-status field from reading list

### DIFF
--- a/cmd/web/reading_list.templ
+++ b/cmd/web/reading_list.templ
@@ -61,7 +61,6 @@ templ BookDisplay(book model.ReadingList, dc model.DisplayContent, userIsAdmin b
 		<p>Published: { book.Published }</p>
 		<p>ISBN: { book.ISBN }</p>
 		<p>Website: <a href={ templ.SafeURL(book.Website) } target="_blank">{ book.Website }</a></p>
-		<p>Status: { book.Status }</p>
 		<br>
 		<div>I am not affiliated with, nor do I own any rights to, the books listed in my reading list. All purchase links are non-affiliate and provided solely for informational purposes.</div>
 	</div>

--- a/cmd/web/writer.templ
+++ b/cmd/web/writer.templ
@@ -102,16 +102,6 @@ templ BookFormContent(book *model.ReadingList) {
         <input class="form-input" type="url" id="website" name="website" placeholder="https://example.com" value={book.Website}>
     </div>
     <div class="form-field">
-        <label class="form-label" for="status">Status:</label>
-        <select class="form-select" id="status" name="status">
-            <option value="interested" selected?={book.Status == "interested"}>Interested</option>
-            <option value="purchased" selected?={book.Status == "purchased"}>Purchased</option>
-            <option value="reading" selected?={book.Status == "reading"}>Reading</option>
-            <option value="read" selected?={book.Status == "read"}>Read</option>
-            <option value="abandoned" selected?={book.Status == "abandoned"}>Abandoned</option>
-        </select>
-    </div>
-    <div class="form-field">
         <label class="form-label" for="tags">Tags:</label>
         <input class="form-input" type="text" id="tags" name="tags" placeholder="comma-separated" value={strings.Join(book.Tags, ",")} required>
     </div>

--- a/internal/model/reading_list.go
+++ b/internal/model/reading_list.go
@@ -11,7 +11,6 @@ type ReadingList struct {
 	Published string `yaml:"published"`
 	ISBN      string `yaml:"isbn"`
 	Website   string `yaml:"website"`
-	Status    string `yaml:"status"`
 }
 
 // Validate checks that the ReadingList entry has the required fields populated.

--- a/internal/service/reading_list_service_test.go
+++ b/internal/service/reading_list_service_test.go
@@ -83,10 +83,6 @@ func TestGetBook(t *testing.T) {
 		if book.Author != "Test Author" {
 			t.Errorf("expected author 'Test Author', got %q", book.Author)
 		}
-
-		if book.Status != "read" {
-			t.Errorf("expected status 'read', got %q", book.Status)
-		}
 	})
 
 	t.Run("returns error for non-existent key", func(t *testing.T) {

--- a/storage/testdata/reading-list/no-image-book.yaml
+++ b/storage/testdata/reading-list/no-image-book.yaml
@@ -5,6 +5,5 @@ author: Test Author
 published: "2024"
 isbn: ""
 website: ""
-status: interested
 tags:
   - Testing

--- a/storage/testdata/reading-list/test-book.yaml
+++ b/storage/testdata/reading-list/test-book.yaml
@@ -6,7 +6,6 @@ author: Test Author
 published: "2024"
 isbn: "978-0-134685991"
 website: https://example.com/test-book
-status: read
 tags:
   - Data Structures
   - Testing


### PR DESCRIPTION
## Summary
- Remove the `status` field from the `ReadingList` model, templates, and test fixtures
- The status field (interested/purchased/reading/read/abandoned) was admin-facing metadata that added friction to the writer form without providing public-facing value
- Cleans up the display template, writer form select dropdown, model struct, and test assertions

## Test plan
- [x] All existing tests pass with status references removed
- [x] `reading_list_service_test.go` updated to remove status assertion
- [x] Test fixture YAML files updated to remove status field