### PR TITLE
feat: add admin web UI for user management

### DIFF
--- a/cmd/web/admin.templ
+++ b/cmd/web/admin.templ
@@ -13,6 +13,9 @@ templ AdminDisplay() {
             <a href="/admin/documents" class="card-subtitle">Documents</a>
         </div>
         <div>
+            <a href="/admin/users" class="card-subtitle">Users</a>
+        </div>
+        <div>
             <a href="/letters" class="card-subtitle">Letters</a>
         </div>
         <div>

--- a/cmd/web/admin_users.go
+++ b/cmd/web/admin_users.go
@@ -60,7 +60,7 @@ func CreateUserHandler(w http.ResponseWriter, r *http.Request, a *auth.Auth) {
 
 	err := a.CreateUser(r.Context(), firstName, lastName, email, password)
 	if err != nil {
-		HandleError(w, r, apperrors.InternalServerError(err), "CreateUserHandler", "createUser")
+		renderUserResult(w, r, "Failed to create user. Please try again.", true)
 
 		return
 	}

--- a/cmd/web/admin_users.go
+++ b/cmd/web/admin_users.go
@@ -1,0 +1,85 @@
+package web
+
+import (
+	"net/http"
+
+	"github.com/a-h/templ"
+
+	"timterests/internal/auth"
+	apperrors "timterests/internal/errors"
+)
+
+// AdminUsersPageHandler handles the admin user creation page at /admin/users.
+func AdminUsersPageHandler(w http.ResponseWriter, r *http.Request, a *auth.Auth) {
+	if !a.IsAuthenticated(r) {
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+
+		return
+	}
+
+	var component templ.Component
+
+	if IsHTMXRequest(r) {
+		SetPartialResponseHeaders(w)
+
+		component = AdminUsersDisplay("")
+	} else {
+		component = AdminUsersPage("")
+	}
+
+	err := renderHTML(w, r, http.StatusOK, component)
+	if err != nil {
+		HandleError(w, r, apperrors.RenderFailed(err), "AdminUsersPageHandler", "render")
+	}
+}
+
+// CreateUserHandler handles POST /admin/users/create to create a new user.
+func CreateUserHandler(w http.ResponseWriter, r *http.Request, a *auth.Auth) {
+	if !a.IsAuthenticated(r) {
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+
+		return
+	}
+
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+
+		return
+	}
+
+	firstName := r.FormValue("first_name")
+	lastName := r.FormValue("last_name")
+	email := r.FormValue("email")
+	password := r.FormValue("password")
+
+	if firstName == "" || lastName == "" || email == "" || password == "" {
+		renderUserResult(w, r, "All fields are required.", true)
+
+		return
+	}
+
+	err := a.CreateUser(r.Context(), firstName, lastName, email, password)
+	if err != nil {
+		renderUserResult(w, r, "Failed to create user: "+err.Error(), true)
+
+		return
+	}
+
+	renderUserResult(w, r, "User created successfully.", false)
+}
+
+func renderUserResult(w http.ResponseWriter, r *http.Request, message string, isError bool) {
+	SetPartialResponseHeaders(w)
+
+	status := http.StatusOK
+	if isError {
+		status = http.StatusUnprocessableEntity
+	}
+
+	component := CreateUserResult(message, isError)
+
+	err := renderHTML(w, r, status, component)
+	if err != nil {
+		HandleError(w, r, apperrors.RenderFailed(err), "CreateUserHandler", "renderResult")
+	}
+}

--- a/cmd/web/admin_users.go
+++ b/cmd/web/admin_users.go
@@ -42,7 +42,7 @@ func CreateUserHandler(w http.ResponseWriter, r *http.Request, a *auth.Auth) {
 	}
 
 	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		HandleError(w, r, apperrors.MethodNotAllowed(), "CreateUserHandler", "method")
 
 		return
 	}
@@ -60,7 +60,7 @@ func CreateUserHandler(w http.ResponseWriter, r *http.Request, a *auth.Auth) {
 
 	err := a.CreateUser(r.Context(), firstName, lastName, email, password)
 	if err != nil {
-		renderUserResult(w, r, "Failed to create user: "+err.Error(), true)
+		HandleError(w, r, apperrors.InternalServerError(err), "CreateUserHandler", "createUser")
 
 		return
 	}

--- a/cmd/web/admin_users.templ
+++ b/cmd/web/admin_users.templ
@@ -1,0 +1,50 @@
+package web
+
+templ AdminUsersPage(resultMsg string) {
+	@Base("admin") {
+		@AdminUsersDisplay(resultMsg)
+	}
+}
+
+templ AdminUsersDisplay(resultMsg string) {
+	<div id="admin-users-container">
+		<h1 class="category-title">Create User</h1>
+		<form
+			hx-post="/admin/users/create"
+			hx-target="#create-user-result"
+			hx-swap="innerHTML"
+			class="form-container"
+		>
+			<div class="form-field">
+				<label class="form-label" for="first_name">First Name:</label>
+				<input class="form-input" type="text" id="first_name" name="first_name" required/>
+			</div>
+			<div class="form-field">
+				<label class="form-label" for="last_name">Last Name:</label>
+				<input class="form-input" type="text" id="last_name" name="last_name" required/>
+			</div>
+			<div class="form-field">
+				<label class="form-label" for="email">Email:</label>
+				<input class="form-input" type="email" id="email" name="email" required/>
+			</div>
+			<div class="form-field">
+				<label class="form-label" for="password">Password:</label>
+				<input class="form-input" type="password" id="password" name="password" required/>
+			</div>
+			<button type="submit" class="button">Create User</button>
+		</form>
+		<div id="create-user-result">
+			if resultMsg != "" {
+				<p class="card-subtitle">{ resultMsg }</p>
+			}
+		</div>
+	</div>
+}
+
+templ CreateUserResult(message string, isError bool) {
+	if isError {
+		<p class="error-message">{ message }</p>
+	} else {
+		<p class="card-subtitle">{ message }</p>
+	}
+}

--- a/cmd/web/admin_users_test.go
+++ b/cmd/web/admin_users_test.go
@@ -108,6 +108,7 @@ func TestCreateUserHandler(t *testing.T) {
 			strings.NewReader(form.Encode()),
 		)
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
 		rec := httptest.NewRecorder()
 
 		web.CreateUserHandler(rec, req, a)
@@ -143,6 +144,7 @@ func TestCreateUserHandler(t *testing.T) {
 			strings.NewReader(form.Encode()),
 		)
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
 		rec := httptest.NewRecorder()
 
 		addAuthCookie(req)

--- a/cmd/web/admin_users_test.go
+++ b/cmd/web/admin_users_test.go
@@ -87,8 +87,16 @@ func TestAdminUsersPageHandler(t *testing.T) {
 			t.Error("expected no title element for partial render, but found one")
 		}
 
+		if doc.Find(`[id="admin-users-container"]`).Length() == 0 {
+			t.Error("expected admin-users-container, but it wasn't found")
+		}
+
 		if cc := rec.Header().Get("Cache-Control"); !strings.Contains(cc, "no-store") {
 			t.Errorf("expected Cache-Control to contain no-store, got %q", cc)
+		}
+
+		if vary := rec.Header().Get("Vary"); !strings.Contains(vary, "HX-Request") {
+			t.Errorf("expected Vary to contain HX-Request, got %q", vary)
 		}
 	})
 }

--- a/cmd/web/admin_users_test.go
+++ b/cmd/web/admin_users_test.go
@@ -1,0 +1,166 @@
+package web_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"timterests/cmd/web"
+	"timterests/internal/auth"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+func TestAdminUsersPageHandler(t *testing.T) {
+	t.Run("redirects to login when unauthenticated", func(t *testing.T) {
+		a := auth.NewAuth("test-session-key-minimum-32-bytes")
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/admin/users", nil)
+		rec := httptest.NewRecorder()
+
+		web.AdminUsersPageHandler(rec, req, a)
+
+		if rec.Code != http.StatusSeeOther {
+			t.Errorf("expected status %d, got %d", http.StatusSeeOther, rec.Code)
+		}
+
+		if loc := rec.Header().Get("Location"); loc != "/login" {
+			t.Errorf("expected redirect to /login, got %q", loc)
+		}
+	})
+
+	t.Run("renders full page when authenticated", func(t *testing.T) {
+		a, addAuthCookie := testAuthentication(t)
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/admin/users", nil)
+		rec := httptest.NewRecorder()
+
+		addAuthCookie(req)
+
+		web.AdminUsersPageHandler(rec, req, a)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+
+		doc, err := goquery.NewDocumentFromReader(rec.Body)
+		if err != nil {
+			t.Fatalf("failed to parse response: %v", err)
+		}
+
+		if doc.Find("title").Length() == 0 {
+			t.Error("expected title element to be rendered")
+		}
+
+		if doc.Find(`[id="admin-users-container"]`).Length() == 0 {
+			t.Error("expected admin-users-container, but it wasn't found")
+		}
+
+		if doc.Find("h1.category-title").Text() != "Create User" {
+			t.Errorf("expected page title 'Create User', got %q", doc.Find("h1.category-title").Text())
+		}
+	})
+
+	t.Run("renders partial on HTMX request", func(t *testing.T) {
+		a, addAuthCookie := testAuthentication(t)
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/admin/users", nil)
+		rec := httptest.NewRecorder()
+
+		addAuthCookie(req)
+		req.Header.Set("Hx-Request", "true")
+
+		web.AdminUsersPageHandler(rec, req, a)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+
+		doc, err := goquery.NewDocumentFromReader(rec.Body)
+		if err != nil {
+			t.Fatalf("failed to parse response: %v", err)
+		}
+
+		if doc.Find("title").Length() > 0 {
+			t.Error("expected no title element for partial render, but found one")
+		}
+
+		if cc := rec.Header().Get("Cache-Control"); !strings.Contains(cc, "no-store") {
+			t.Errorf("expected Cache-Control to contain no-store, got %q", cc)
+		}
+	})
+}
+
+func TestCreateUserHandler(t *testing.T) {
+	t.Run("redirects to login when unauthenticated", func(t *testing.T) {
+		a := auth.NewAuth("test-session-key-minimum-32-bytes")
+
+		form := url.Values{}
+		form.Set("first_name", "Test")
+		form.Set("last_name", "User")
+		form.Set("email", "test@example.com")
+		form.Set("password", "password123")
+
+		req := httptest.NewRequestWithContext(
+			context.Background(), http.MethodPost, "/admin/users/create",
+			strings.NewReader(form.Encode()),
+		)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		rec := httptest.NewRecorder()
+
+		web.CreateUserHandler(rec, req, a)
+
+		if rec.Code != http.StatusSeeOther {
+			t.Errorf("expected status %d, got %d", http.StatusSeeOther, rec.Code)
+		}
+	})
+
+	t.Run("rejects non-POST method", func(t *testing.T) {
+		a, addAuthCookie := testAuthentication(t)
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/admin/users/create", nil)
+		rec := httptest.NewRecorder()
+
+		addAuthCookie(req)
+
+		web.CreateUserHandler(rec, req, a)
+
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected status %d, got %d", http.StatusMethodNotAllowed, rec.Code)
+		}
+	})
+
+	t.Run("returns error when fields are missing", func(t *testing.T) {
+		a, addAuthCookie := testAuthentication(t)
+
+		form := url.Values{}
+		form.Set("first_name", "Test")
+
+		req := httptest.NewRequestWithContext(
+			context.Background(), http.MethodPost, "/admin/users/create",
+			strings.NewReader(form.Encode()),
+		)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		rec := httptest.NewRecorder()
+
+		addAuthCookie(req)
+
+		web.CreateUserHandler(rec, req, a)
+
+		if rec.Code != http.StatusUnprocessableEntity {
+			t.Errorf("expected status %d, got %d", http.StatusUnprocessableEntity, rec.Code)
+		}
+
+		doc, err := goquery.NewDocumentFromReader(rec.Body)
+		if err != nil {
+			t.Fatalf("failed to parse response: %v", err)
+		}
+
+		errorMsg := doc.Find(".error-message").Text()
+		if errorMsg == "" {
+			t.Error("expected error message, but none found")
+		}
+	})
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -48,6 +48,13 @@ func (s *Server) RegisterRoutes() http.Handler {
 		web.AdminDocumentsPageHandler(w, r, *s.Storage, s.auth)
 	}))
 
+	mux.Handle("/admin/users", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		web.AdminUsersPageHandler(w, r, s.auth)
+	}))
+	mux.Handle("/admin/users/create", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		web.CreateUserHandler(w, r, s.auth)
+	}))
+
 	mux.Handle("/writer", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var (
 			docType, key string

--- a/internal/storage/parser_test.go
+++ b/internal/storage/parser_test.go
@@ -91,6 +91,59 @@ func TestGetTags(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("get tags from embedded document struct", func(t *testing.T) {
+		t.Parallel()
+
+		article := model.Article{
+			Document: model.Document{
+				Tags: []string{"go", "web"},
+			},
+			Date: "2026-01-01",
+		}
+
+		var tags []string
+
+		v := reflect.ValueOf(article)
+		tags = storage.GetTags(v, tags)
+
+		if len(tags) != 2 || tags[0] != "go" || tags[1] != "web" {
+			t.Errorf("Expected [go web], got %v", tags)
+		}
+	})
+
+	t.Run("deduplicates tags", func(t *testing.T) {
+		t.Parallel()
+
+		document := model.Document{
+			Tags: []string{"go", "web"},
+		}
+
+		existing := []string{"go"}
+
+		v := reflect.ValueOf(document)
+		tags := storage.GetTags(v, existing)
+
+		if len(tags) != 2 || tags[0] != "go" || tags[1] != "web" {
+			t.Errorf("Expected [go web], got %v", tags)
+		}
+	})
+
+	t.Run("returns existing tags for struct without tags field", func(t *testing.T) {
+		t.Parallel()
+
+		type NoTags struct {
+			Name string
+		}
+
+		v := reflect.ValueOf(NoTags{Name: "test"})
+		existing := []string{"existing"}
+		tags := storage.GetTags(v, existing)
+
+		if len(tags) != 1 || tags[0] != "existing" {
+			t.Errorf("Expected [existing], got %v", tags)
+		}
+	})
 }
 
 func TestHTMLParsing(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `/admin/users` page with a form to create new users via the browser
- Uses existing `auth.CreateUser()` — no new auth logic needed
- HTMX partial support for form submission with success/error feedback
- Auth guard redirects unauthenticated requests to `/login`
- Admin dashboard updated with "Users" link

Closes #155

## Test plan
- [x] `AdminUsersPageHandler` — redirects unauthenticated, renders full page, renders HTMX partial
- [x] `CreateUserHandler` — redirects unauthenticated, rejects non-POST, validates required fields
- [x] All 6 new tests pass
- [x] `make build` passes
- [x] `make test` passes (full suite)