### PR TITLE
feat: add make create-user target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ make test       # Run all tests with verbose output (go test ./... -v)
 make watch      # Live reload with air
 make coverage   # Coverage report excluding generated _templ.go files
 make clean      # Remove binary and tmp files
+make create-user FIRST=John LAST=Doe EMAIL=john@example.com PASS=secret  # Bootstrap a user
 ```
 
 Run a single test:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ make test       # Run all tests with verbose output (go test ./... -v)
 make watch      # Live reload with air
 make coverage   # Coverage report excluding generated _templ.go files
 make clean      # Remove binary and tmp files
-make create-user FIRST=John LAST=Doe EMAIL=john@example.com PASS=secret  # Bootstrap a user
+export DB_PASSWORD=<your-password> && make create-user FIRST=John LAST=Doe EMAIL=john@example.com  # Bootstrap a user
 ```
 
 Run a single test:

--- a/Makefile
+++ b/Makefile
@@ -75,11 +75,11 @@ complexity:
 
 # Create a new user (for bootstrapping the first admin before the web UI is available)
 create-user:
-	@if [ -z "$(FIRST)" ] || [ -z "$(LAST)" ] || [ -z "$(EMAIL)" ] || [ -z "$(PASS)" ]; then \
-		echo "Usage: make create-user FIRST=John LAST=Doe EMAIL=john@example.com PASS=secret"; \
+	@if [ -z "$(FIRST)" ] || [ -z "$(LAST)" ] || [ -z "$(EMAIL)" ] || [ -z "$(DB_PASSWORD)" ]; then \
+		echo "Usage: export DB_PASSWORD=secret && make create-user FIRST=John LAST=Doe EMAIL=john@example.com"; \
 		exit 1; \
 	fi
-	@go run internal/utils/main.go create-user "$(FIRST)" "$(LAST)" "$(EMAIL)" "$(PASS)"
+	@go run internal/utils/main.go create-user "$(FIRST)" "$(LAST)" "$(EMAIL)" "$(DB_PASSWORD)"
 	@echo "User created successfully."
 
 # Clean the binary and temp files
@@ -117,4 +117,4 @@ deploy:
 	fi
 
 
-.PHONY: all build run test coverage clean watch templ-install create-user deploy complexity
+.PHONY: all build run test coverage clean watch templ-install create-user deploy complexity docker-run docker-down

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,15 @@ complexity:
 		fi; \
 	fi
 
+# Create a new user (for bootstrapping the first admin before the web UI is available)
+create-user:
+	@if [ -z "$(FIRST)" ] || [ -z "$(LAST)" ] || [ -z "$(EMAIL)" ] || [ -z "$(PASS)" ]; then \
+		echo "Usage: make create-user FIRST=John LAST=Doe EMAIL=john@example.com PASS=secret"; \
+		exit 1; \
+	fi
+	@go run internal/utils/main.go create-user "$(FIRST)" "$(LAST)" "$(EMAIL)" "$(PASS)"
+	@echo "User created successfully."
+
 # Clean the binary and temp files
 clean:
 	@echo "Cleaning..."
@@ -108,4 +117,4 @@ deploy:
 	fi
 
 
-.PHONY: all build run test coverage clean watch templ-install
+.PHONY: all build run test coverage clean watch templ-install create-user deploy complexity


### PR DESCRIPTION
## Summary
- Add `make create-user` Makefile target wrapping the existing CLI utility
- Validates all required args (FIRST, LAST, EMAIL, PASS) and prints usage on missing input
- Updated CLAUDE.md commands section to document the new target
- Updated .PHONY to include missing targets (create-user, deploy, complexity)

Complements PR #157 (admin web UI for user management) — this target bootstraps the first admin user before the web UI is accessible.

## Test plan
- [x] `make create-user` with no args prints usage and exits non-zero
- [x] `make build` still works
- [x] `make test` still passes