### PR TITLE
feat: add GoatCounter analytics support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ Controlled by the `USE_S3` env var. In local mode, files are read directly from 
 | `AWS_BUCKET_NAME`                | S3 bucket (required if `USE_S3=true`)             |
 | `AWS_REGION`                     | AWS region (required if `USE_S3=true`)            |
 | `OPENAI_API_KEY`                 | Required for AI writer suggestions                |
+| `GOATCOUNTER_URL`                | GoatCounter subdomain (e.g. `mysite.goatcounter.com`); omit to disable analytics |
 | `SSL_CERT_FILE` / `SSL_KEY_FILE` | Optional TLS; server falls back to HTTP if absent |
 
 Load via `.env` file — `godotenv/autoload` is imported in `internal/server/server.go`.

--- a/cmd/web/base.templ
+++ b/cmd/web/base.templ
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"os"
 	"time"
 	"strconv"
 )
@@ -61,6 +62,11 @@ templ Base(activePage string) {
 					<a href="https://github.com/TheTimbob/timterests" class="nav-footer-link">&copy; { strconv.Itoa(time.Now().Year()) } Tim Scott</a>
 				</p>
 			</footer>
+			if os.Getenv("GOATCOUNTER_URL") != "" {
+				<script data-goatcounter={ "https://" + os.Getenv("GOATCOUNTER_URL") + "/count" }
+					async
+					src="//gc.zgo.at/count.js"></script>
+			}
 		</body>
 	</html>
 }

--- a/cmd/web/base.templ
+++ b/cmd/web/base.templ
@@ -62,8 +62,8 @@ templ Base(activePage string) {
 					<a href="https://github.com/TheTimbob/timterests" class="nav-footer-link">&copy; { strconv.Itoa(time.Now().Year()) } Tim Scott</a>
 				</p>
 			</footer>
-			if os.Getenv("GOATCOUNTER_URL") != "" {
-				<script data-goatcounter={ "https://" + os.Getenv("GOATCOUNTER_URL") + "/count" }
+			if url := os.Getenv("GOATCOUNTER_URL"); url != "" {
+				<script data-goatcounter={ "https://" + url + "/count" }
 					async
 					src="//gc.zgo.at/count.js"></script>
 			}


### PR DESCRIPTION
## Summary
- Adds conditional GoatCounter script tag to the base HTML template (#153)
- Controlled by `GOATCOUNTER_URL` env var — set to your GoatCounter subdomain (e.g. `mysite.goatcounter.com`) to enable, omit to disable
- Privacy-respecting: no cookies, no GDPR consent banner needed
- Zero runtime cost when disabled — script tag not rendered at all

## Setup
1. Sign up at goatcounter.com (free for personal use)
2. Add `GOATCOUNTER_URL=yoursite.goatcounter.com` to `.env`
3. Restart the server

Closes #153

## Test plan
- [ ] Verify no script tag rendered when `GOATCOUNTER_URL` is unset
- [ ] Verify correct script tag rendered when `GOATCOUNTER_URL` is set
- [ ] Confirm all existing tests pass