### PR TITLE
feat: add time spans to projects

### DIFF
--- a/cmd/web/adapters.go
+++ b/cmd/web/adapters.go
@@ -24,7 +24,7 @@ func ProjectCard(p model.Project, i int) components.Card {
 	return components.Card{
 		Title:     p.Title,
 		Subtitle:  p.Subtitle,
-		Date:      "",
+		Date:      p.Timespan(),
 		Preview:   p.Preview,
 		ImagePath: p.Image,
 		Get:       "/project?id=" + p.ID,

--- a/cmd/web/adapters_test.go
+++ b/cmd/web/adapters_test.go
@@ -128,8 +128,9 @@ func TestProjectAdapters(t *testing.T) {
 			t.Errorf("card ImagePath: got %q, want %q", card.ImagePath, mp.Image)
 		}
 
-		if card.Date != "" {
-			t.Errorf("project card should have no Date, got %q", card.Date)
+		expectedDate := mp.Timespan()
+		if card.Date != expectedDate {
+			t.Errorf("card Date: got %q, want %q", card.Date, expectedDate)
 		}
 	})
 }

--- a/cmd/web/projects.go
+++ b/cmd/web/projects.go
@@ -76,9 +76,9 @@ func GetProjectHandler(w http.ResponseWriter, r *http.Request, s storage.Storage
 			if IsHTMXRequest(r) {
 				SetPartialResponseHeaders(w)
 
-				component = ProjectDisplay(dc, project.Repository, authenticated)
+				component = ProjectDisplay(dc, project.Repository, project.Timespan(), authenticated)
 			} else {
-				component = ProjectPage(dc, project.Repository, authenticated)
+				component = ProjectPage(dc, project.Repository, project.Timespan(), authenticated)
 			}
 
 			err = renderHTML(w, r, http.StatusOK, component)

--- a/cmd/web/projects.templ
+++ b/cmd/web/projects.templ
@@ -46,16 +46,19 @@ templ ProjectsList(projects []model.Project, design string) {
 	</ul>
 }
 
-templ ProjectPage(dc model.DisplayContent, repository string, userIsAdmin bool) {
+templ ProjectPage(dc model.DisplayContent, repository string, timespan string, userIsAdmin bool) {
     @Base("projects") {
-        @ProjectDisplay(dc, repository, userIsAdmin)
+        @ProjectDisplay(dc, repository, timespan, userIsAdmin)
     }
 }
 
-templ ProjectDisplay(dc model.DisplayContent, repository string, userIsAdmin bool) {
+templ ProjectDisplay(dc model.DisplayContent, repository string, timespan string, userIsAdmin bool) {
     @EditProjectButton(dc, userIsAdmin)
     @components.DownloadDocumentButton(dc.S3Key, userIsAdmin)
     <div id="project-container">
+		if timespan != "" {
+			<p class="card-date">{ timespan }</p>
+		}
 		if repository != "" && repository != "Private" {
 			<p class="content-text"><i class="fa-brands fa-github"></i> Repository: <a href={ templ.SafeURL(repository) } class="content-text" target="_blank">{ repository }</a></p>
 		}

--- a/cmd/web/projects_test.go
+++ b/cmd/web/projects_test.go
@@ -246,17 +246,17 @@ func TestProjectCardConversion(t *testing.T) {
 			t.Errorf("expected card get URL '/project?id=1', got %q", card.Get)
 		}
 
-		// Projects should have ImagePath but no Date
 		if card.ImagePath == "" {
 			t.Error("expected card image path to be set, but it was empty")
 		}
 
-		if card.Date != "" {
-			t.Errorf("expected card date to be empty for projects, got %q", card.Date)
-		}
-
 		if card.ImagePath != project.Image {
 			t.Errorf("expected card image path %q, got %q", project.Image, card.ImagePath)
+		}
+
+		expectedDate := project.Timespan()
+		if card.Date != expectedDate {
+			t.Errorf("expected card date %q, got %q", expectedDate, card.Date)
 		}
 	})
 }
@@ -269,7 +269,7 @@ func TestProjectRepositoryRendering(t *testing.T) {
 
 		var buf bytes.Buffer
 
-		err := web.ProjectDisplay(dc, repository, false).Render(context.Background(), &buf)
+		err := web.ProjectDisplay(dc, repository, "", false).Render(context.Background(), &buf)
 		if err != nil {
 			t.Fatalf("failed to render ProjectDisplay: %v", err)
 		}

--- a/cmd/web/writer.templ
+++ b/cmd/web/writer.templ
@@ -132,6 +132,14 @@ templ ProjectFormContent(project *model.Project) {
         <input class="form-input" type="text" id="repository" name="repository" placeholder="GitHub repository URL" value={project.Repository} required>
     </div>
     <div class="form-field">
+        <label class="form-label" for="startDate">Start Date:</label>
+        <input class="form-input" type="text" id="startDate" name="startDate" placeholder="e.g. Jan 2023" value={project.StartDate}>
+    </div>
+    <div class="form-field">
+        <label class="form-label" for="endDate">End Date:</label>
+        <input class="form-input" type="text" id="endDate" name="endDate" placeholder="Leave blank for ongoing" value={project.EndDate}>
+    </div>
+    <div class="form-field">
         <label class="form-label" for="tags">Tags:</label>
         <input class="form-input" type="text" id="tags" name="tags" placeholder="Comma Separated" value={strings.Join(project.Tags, ",")} required>
     </div>

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -59,6 +59,35 @@ func TestProjectValidate(t *testing.T) {
 	})
 }
 
+func TestProjectTimespan(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		start     string
+		end       string
+		expected  string
+	}{
+		{"both dates", "Jan 2023", "Dec 2024", "Jan 2023 — Dec 2024"},
+		{"ongoing project", "Mar 2024", "", "Mar 2024 — Present"},
+		{"no dates", "", "", ""},
+		{"no start ignores end", "", "Dec 2024", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := model.Project{StartDate: tc.start, EndDate: tc.end}
+
+			result := p.Timespan()
+			if result != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, result)
+			}
+		})
+	}
+}
+
 func TestLetterValidate(t *testing.T) {
 	t.Run("valid letter passes validation", func(t *testing.T) {
 		l := model.Letter{

--- a/internal/model/project.go
+++ b/internal/model/project.go
@@ -8,6 +8,21 @@ type Project struct {
 
 	Repository string `yaml:"repository"`
 	Image      string `yaml:"imagePath"`
+	StartDate  string `yaml:"startDate"`
+	EndDate    string `yaml:"endDate"`
+}
+
+// Timespan returns a formatted date range for display.
+func (p *Project) Timespan() string {
+	if p.StartDate == "" {
+		return ""
+	}
+
+	if p.EndDate == "" {
+		return p.StartDate + " — Present"
+	}
+
+	return p.StartDate + " — " + p.EndDate
 }
 
 // Validate checks that the Project has the required fields populated.

--- a/storage/testdata/projects/test-project.yaml
+++ b/storage/testdata/projects/test-project.yaml
@@ -3,6 +3,8 @@ subtitle: This is a test project.
 preview: A brief preview of the test project.
 imagePath: testdata/images/test.png
 repository: Private
+startDate: Jan 2024
+endDate: ""
 tags:
   - Golang
   - HTMX


### PR DESCRIPTION
## Summary
- Adds `StartDate` and `EndDate` fields to the Project model (#49)
- `Timespan()` method formats display: "Jan 2023 — Present" (ongoing) or "Jan 2023 — Dec 2024" (completed)
- Projects without dates continue showing no date — fully backwards compatible
- Updated: model, card adapter, detail page template, writer form, tests, test fixtures

## Test plan
- [ ] Verify projects with both dates show "Start — End" format
- [ ] Verify projects with only start date show "Start — Present"
- [ ] Verify projects with no dates show no date field
- [ ] Verify writer form shows start/end date inputs
- [ ] All existing tests pass

Closes #49