### PR TITLE
feat: improve accessibility across all pages

### DIFF
--- a/cmd/web/assets/css/styles.css
+++ b/cmd/web/assets/css/styles.css
@@ -42,6 +42,29 @@
   }
 }
 
+/* Accessibility */
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 1rem;
+  padding: 0.5rem 1rem;
+  background: var(--green);
+  color: #fff;
+  border-radius: 0 0 0.25rem 0.25rem;
+  z-index: 1000;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.skip-link:focus {
+  top: 0;
+}
+
+*:focus-visible {
+  outline: 2px solid var(--green);
+  outline-offset: 2px;
+}
+
 .animate-fade-in {
   animation: fadeIn 0.8s ease-out forwards;
 }

--- a/cmd/web/base.templ
+++ b/cmd/web/base.templ
@@ -22,35 +22,36 @@ templ Base(activePage string) {
 		<link rel="icon" type="image/png" href="/assets/images/favicon.png" />
 	</head>
 		<body>
+			<a href="#main-content" class="skip-link">Skip to content</a>
 			<header class="banner-header">
 				<a href="/" class="no-underline banner-title-link">
 					<img src="/assets/images/logo.png" alt="" aria-hidden="true" class="banner-logo" />
 					<h1 class="banner-title">Timterests</h1>
 				</a>
 				<div class="dark-mode-switch">
-					<input type="checkbox" class="dark-mode-switch-input" id="dark-mode-switch">
+					<input type="checkbox" class="dark-mode-switch-input" id="dark-mode-switch" aria-label="Toggle dark mode">
 					<label class="dark-mode-switch-label" for="dark-mode-switch">
 						<span class="dark-mode-switch-indicator"></span>
 					</label>
 				</div>
 				<p class="banner-subtitle">Tim's interests</p>
 			</header>
-			<nav class="nav-header">
-				<input type="checkbox" id="nav-toggle" class="nav-toggle-input" />
-				<label for="nav-toggle" class="nav-toggle-label"><i class="fa-solid fa-bars"></i></label>
+			<nav class="nav-header" aria-label="Main navigation">
+				<input type="checkbox" id="nav-toggle" class="nav-toggle-input" aria-label="Toggle navigation menu" />
+				<label for="nav-toggle" class="nav-toggle-label" aria-hidden="true"><i class="fa-solid fa-bars"></i></label>
 				<div class="nav-links">
-					<a href="/home" class={ "nav-link", templ.KV("active", activePage == "home") }><i class="fa-solid fa-house"></i> Home</a>
-					<a href="/articles" class={ "nav-link", templ.KV("active", activePage == "articles") }><i class="fa-solid fa-newspaper"></i> Articles</a>
-					<a href="/projects" class={ "nav-link", templ.KV("active", activePage == "projects") }><i class="fa-brands fa-github"></i> Projects</a>
-					<a href="/reading-list" class={ "nav-link", templ.KV("active", activePage == "reading-list") }><i class="fa-solid fa-book"></i> Reading List</a>
-					<a href="/about" class={ "nav-link", templ.KV("active", activePage == "about") }><i class="fa-solid fa-question"></i> About</a>
+					<a href="/home" class={ "nav-link", templ.KV("active", activePage == "home") }><i class="fa-solid fa-house" aria-hidden="true"></i> Home</a>
+					<a href="/articles" class={ "nav-link", templ.KV("active", activePage == "articles") }><i class="fa-solid fa-newspaper" aria-hidden="true"></i> Articles</a>
+					<a href="/projects" class={ "nav-link", templ.KV("active", activePage == "projects") }><i class="fa-brands fa-github" aria-hidden="true"></i> Projects</a>
+					<a href="/reading-list" class={ "nav-link", templ.KV("active", activePage == "reading-list") }><i class="fa-solid fa-book" aria-hidden="true"></i> Reading List</a>
+					<a href="/about" class={ "nav-link", templ.KV("active", activePage == "about") }><i class="fa-solid fa-question" aria-hidden="true"></i> About</a>
 				</div>
 			</nav>
-			<main id="main-content" class="main-content animate-fade-in">
+			<main id="main-content" class="main-content animate-fade-in" aria-live="polite">
 				{ children... }
 			</main>
 			<footer class="banner-footer">
-				<nav class="footer-nav">
+				<nav class="footer-nav" aria-label="Footer navigation">
 					<a href="/home" class="nav-footer-link">Home</a>
 					<a href="/articles" class="nav-footer-link">Articles</a>
 					<a href="/projects" class="nav-footer-link">Projects</a>

--- a/cmd/web/components/card.templ
+++ b/cmd/web/components/card.templ
@@ -18,8 +18,8 @@ func (c Card) animationDelay() string {
 }
 
 templ (c Card) LargeCard() {
-	<div class="card-container animate-slide-up" style={ c.animationDelay() } hx-get={ c.Get } hx-target="#main-content" hx-swap="innerHTML" hx-push-url="true" tabindex="0">
-        @c.renderImage("Card image")
+	<div class="card-container animate-slide-up" style={ c.animationDelay() } hx-get={ c.Get } hx-target="#main-content" hx-swap="innerHTML" hx-push-url="true" tabindex="0" role="link" aria-label={ c.Title }>
+        @c.renderImage(c.Title)
         <div class="card-content">
             @CardTitleContainer(c.Title, c.Subtitle)
             <div class="card-body">
@@ -32,8 +32,8 @@ templ (c Card) LargeCard() {
 }
 
 templ (c Card) MiniCard() {
-	<div class="mini-card-container animate-slide-up" style={ c.animationDelay() } hx-get={ c.Get } hx-target="#main-content" hx-swap="innerHTML" hx-push-url="true" tabindex="0">
-        @c.renderImage("Mini card image")
+	<div class="mini-card-container animate-slide-up" style={ c.animationDelay() } hx-get={ c.Get } hx-target="#main-content" hx-swap="innerHTML" hx-push-url="true" tabindex="0" role="link" aria-label={ c.Title }>
+        @c.renderImage(c.Title)
         <div class="card-content">
 			<div class="card-title-container">
 				<h2 class="card-subtitle">{ c.Title }</h2>
@@ -45,7 +45,7 @@ templ (c Card) MiniCard() {
 }
 
 templ (c Card) LinkCard() {
-    <div class="link-item animate-slide-up" style={ c.animationDelay() } hx-get={ c.Get } hx-target="#main-content" hx-swap="innerHTML" hx-push-url="true" tabindex="0">
+    <div class="link-item animate-slide-up" style={ c.animationDelay() } hx-get={ c.Get } hx-target="#main-content" hx-swap="innerHTML" hx-push-url="true" tabindex="0" role="link" aria-label={ c.Title }>
         if c.Date != "" {
             <p>{ c.Date } - { c.Title } </p>
         } else {


### PR DESCRIPTION
## Summary
- Add skip-to-content link for keyboard navigation (#41)
- ARIA labels on dark mode toggle and mobile nav hamburger
- `aria-hidden="true"` on decorative Font Awesome icons in nav
- `role="link"` and `aria-label` on card components (they use `hx-get` instead of `<a>`)
- `aria-live="polite"` on main content area so screen readers announce HTMX content swaps
- `aria-label` on main and footer nav landmarks to distinguish them
- `focus-visible` outlines using the site's green accent color

Closes #41

## Test plan
- [ ] Tab through the page — skip link appears on first Tab press
- [ ] Screen reader announces nav links correctly (no icon noise)
- [ ] Cards are announced with their title
- [ ] HTMX page transitions are announced to screen readers
- [ ] Dark mode toggle is labeled for screen readers