### PR TITLE
feat: comprehensive SEO — page titles, meta tags, sitemap, robots.txt, JSON-LD

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ Controlled by the `USE_S3` env var. In local mode, files are read directly from 
 | `AWS_REGION`                     | AWS region (required if `USE_S3=true`)            |
 | `OPENAI_API_KEY`                 | Required for AI writer suggestions                |
 | `GOATCOUNTER_URL`                | GoatCounter subdomain (e.g. `mysite.goatcounter.com`); omit to disable analytics |
+| `SITE_URL`                       | Base URL for SEO (canonical, sitemap, OG tags)    |
 | `SSL_CERT_FILE` / `SSL_KEY_FILE` | Optional TLS; server falls back to HTTP if absent |
 
 Load via `.env` file — `godotenv/autoload` is imported in `internal/server/server.go`.

--- a/cmd/web/articles.go
+++ b/cmd/web/articles.go
@@ -78,7 +78,7 @@ func GetArticleHandler(w http.ResponseWriter, r *http.Request, s storage.Storage
 
 				component = ArticleDisplay(dc, authenticated)
 			} else {
-				component = ArticlePage(dc, authenticated)
+				component = ArticlePage(article, dc, authenticated)
 			}
 
 			err = renderHTML(w, r, http.StatusOK, component)

--- a/cmd/web/articles.templ
+++ b/cmd/web/articles.templ
@@ -1,9 +1,39 @@
 package web
 
 import (
+	"encoding/json"
 	"timterests/cmd/web/components"
 	"timterests/internal/model"
 )
+
+func articleDescription(a model.Article) string {
+	if a.Subtitle != "" {
+		return a.Subtitle
+	}
+
+	return a.Preview
+}
+
+func buildArticleJSONLD(a model.Article) string {
+	data := map[string]any{
+		"@context":      "https://schema.org",
+		"@type":         "Article",
+		"headline":      a.Title,
+		"description":   articleDescription(a),
+		"datePublished": a.Date,
+		"author": map[string]any{
+			"@type": "Person",
+			"name":  "Tim Scott",
+		},
+	}
+
+	b, err := json.Marshal(data)
+	if err != nil {
+		return ""
+	}
+
+	return string(b)
+}
 
 templ ArticlesListPage(articles []model.Article, tags []string, design string) {
 	@Base("articles") {
@@ -46,10 +76,16 @@ templ ArticlesList(articles []model.Article, design string) {
     </ul>
 }
 
-templ ArticlePage(dc model.DisplayContent, userIsAdmin bool) {
-    @Base("articles") {
-        @ArticleDisplay(dc, userIsAdmin)
-    }
+templ ArticlePage(article model.Article, dc model.DisplayContent, userIsAdmin bool) {
+	@Base("articles", MetaProps{
+		Description: articleDescription(article),
+		PageType:    "article",
+		Title:       article.Title + " | Timterests",
+		URL:         "/article?id=" + article.ID,
+		JSONLD:      buildArticleJSONLD(article),
+	}) {
+		@ArticleDisplay(dc, userIsAdmin)
+	}
 }
 
 templ ArticleDisplay(dc model.DisplayContent, userIsAdmin bool) {

--- a/cmd/web/base.templ
+++ b/cmd/web/base.templ
@@ -6,6 +6,26 @@ import (
 	"strconv"
 )
 
+var pageTitles = map[string]string{
+	"home":         "Timterests",
+	"articles":     "Articles | Timterests",
+	"projects":     "Projects | Timterests",
+	"reading-list": "Reading List | Timterests",
+	"about":        "About | Timterests",
+	"admin":        "Admin | Timterests",
+	"writer":       "Writer | Timterests",
+	"letters":      "Letters | Timterests",
+	"login":        "Login | Timterests",
+}
+
+func pageTitle(activePage string) string {
+	if title, ok := pageTitles[activePage]; ok {
+		return title
+	}
+
+	return "Timterests"
+}
+
 templ Base(activePage string) {
 	<!DOCTYPE html>
 	<html lang="en" class="dark">
@@ -13,7 +33,7 @@ templ Base(activePage string) {
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width,initial-scale=1" />
-		<title>Timterests</title>
+		<title>{ pageTitle(activePage) }</title>
 		<script src="/assets/js/htmx.min.js"></script>
 		<script src="/assets/js/dark-mode.js"></script>
         <script src="/assets/js/buttons.js"></script>

--- a/cmd/web/base.templ
+++ b/cmd/web/base.templ
@@ -1,10 +1,22 @@
 package web
 
 import (
+	"encoding/json"
 	"os"
-	"time"
 	"strconv"
+	"time"
 )
+
+// MetaProps holds SEO and Open Graph metadata for a page.
+// Pass to Base to override per-page defaults (article/project detail pages).
+type MetaProps struct {
+	Description string
+	PageType    string // "website" or "article"
+	Title       string // full title for OG tags
+	URL         string // relative URL path, e.g. "/article?id=123"
+	ImageURL    string // full absolute image URL
+	JSONLD      string // pre-marshaled JSON-LD; empty = auto-derive from activePage
+}
 
 var pageTitles = map[string]string{
 	"home":         "Timterests",
@@ -18,6 +30,22 @@ var pageTitles = map[string]string{
 	"login":        "Login | Timterests",
 }
 
+var pageDescriptions = map[string]string{
+	"home":         "Tim Scott's personal site — articles on software engineering, project showcases, and a curated reading list.",
+	"articles":     "Articles on software engineering, Go, cloud infrastructure, and lessons from building real systems.",
+	"projects":     "Software projects built by Tim Scott — from web apps to developer tools.",
+	"reading-list": "Books that shaped how Tim thinks about software, leadership, and craft.",
+	"about":        "About Tim Scott — software engineer, builder, and lifelong learner.",
+}
+
+var pagePathMap = map[string]string{
+	"home":         "/home",
+	"articles":     "/articles",
+	"projects":     "/projects",
+	"reading-list": "/reading-list",
+	"about":        "/about",
+}
+
 func pageTitle(activePage string) string {
 	if title, ok := pageTitles[activePage]; ok {
 		return title
@@ -26,31 +54,131 @@ func pageTitle(activePage string) string {
 	return "Timterests"
 }
 
-templ Base(activePage string) {
+func siteURL() string {
+	if u := os.Getenv("SITE_URL"); u != "" {
+		return u
+	}
+
+	return "https://timterests.com"
+}
+
+func resolvedMeta(activePage string, metas []MetaProps) MetaProps {
+	var m MetaProps
+
+	if len(metas) > 0 {
+		m = metas[0]
+	}
+
+	if m.Description == "" {
+		if desc, ok := pageDescriptions[activePage]; ok {
+			m.Description = desc
+		} else {
+			m.Description = "Tim Scott's personal site — articles, projects, and a curated reading list."
+		}
+	}
+
+	if m.Title == "" {
+		m.Title = pageTitle(activePage)
+	}
+
+	if m.PageType == "" {
+		m.PageType = "website"
+	}
+
+	if m.URL == "" {
+		if path, ok := pagePathMap[activePage]; ok {
+			m.URL = path
+		}
+	}
+
+	if m.ImageURL == "" {
+		m.ImageURL = siteURL() + "/assets/images/logo.png"
+	}
+
+	return m
+}
+
+func pageJSONLD(activePage string, m MetaProps) string {
+	if m.JSONLD != "" {
+		return m.JSONLD
+	}
+
+	var data map[string]any
+
+	switch activePage {
+	case "home":
+		data = map[string]any{
+			"@context":    "https://schema.org",
+			"@type":       "Organization",
+			"name":        "Timterests",
+			"url":         siteURL(),
+			"logo":        siteURL() + "/assets/images/logo.png",
+			"description": "Tim Scott's personal blog and portfolio",
+		}
+	case "about":
+		data = map[string]any{
+			"@context": "https://schema.org",
+			"@type":    "Person",
+			"name":     "Tim Scott",
+			"url":      siteURL() + "/about",
+		}
+	default:
+		return ""
+	}
+
+	b, err := json.Marshal(data)
+	if err != nil {
+		return ""
+	}
+
+	return string(b)
+}
+
+templ headMeta(activePage string, m MetaProps) {
+	<meta name="description" content={ m.Description }/>
+	<meta property="og:title" content={ m.Title }/>
+	<meta property="og:description" content={ m.Description }/>
+	<meta property="og:type" content={ m.PageType }/>
+	if m.URL != "" {
+		<meta property="og:url" content={ siteURL() + m.URL }/>
+		<link rel="canonical" href={ siteURL() + m.URL }/>
+	}
+	<meta property="og:image" content={ m.ImageURL }/>
+	<meta name="twitter:card" content="summary_large_image"/>
+	<meta name="twitter:title" content={ m.Title }/>
+	<meta name="twitter:description" content={ m.Description }/>
+	if ld := pageJSONLD(activePage, m); ld != "" {
+		<script type="application/ld+json">
+			@templ.Raw(ld)
+		</script>
+	}
+}
+
+templ Base(activePage string, metas ...MetaProps) {
 	<!DOCTYPE html>
 	<html lang="en" class="dark">
-
-	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width,initial-scale=1" />
-		<title>{ pageTitle(activePage) }</title>
-		<script src="/assets/js/htmx.min.js"></script>
-		<script src="/assets/js/dark-mode.js"></script>
-        <script src="/assets/js/buttons.js"></script>
-		<script src="https://kit.fontawesome.com/3453ab8a44.js" crossorigin="anonymous"></script>
-		<link href="/assets/css/dark-mode-switch.css" rel="stylesheet" />
-		<link href="/assets/css/styles.css" rel="stylesheet" />
-		<link rel="icon" type="image/png" href="/assets/images/favicon.png" />
-	</head>
+		<head>
+			<meta charset="utf-8"/>
+			<meta name="viewport" content="width=device-width,initial-scale=1"/>
+			<title>{ resolvedMeta(activePage, metas).Title }</title>
+			@headMeta(activePage, resolvedMeta(activePage, metas))
+			<script src="/assets/js/htmx.min.js"></script>
+			<script src="/assets/js/dark-mode.js"></script>
+			<script src="/assets/js/buttons.js"></script>
+			<script src="https://kit.fontawesome.com/3453ab8a44.js" crossorigin="anonymous"></script>
+			<link href="/assets/css/dark-mode-switch.css" rel="stylesheet"/>
+			<link href="/assets/css/styles.css" rel="stylesheet"/>
+			<link rel="icon" type="image/png" href="/assets/images/favicon.png"/>
+		</head>
 		<body>
 			<a href="#main-content" class="skip-link">Skip to content</a>
 			<header class="banner-header">
 				<a href="/" class="no-underline banner-title-link">
-					<img src="/assets/images/logo.png" alt="" aria-hidden="true" class="banner-logo" />
+					<img src="/assets/images/logo.png" alt="" aria-hidden="true" class="banner-logo"/>
 					<h1 class="banner-title">Timterests</h1>
 				</a>
 				<div class="dark-mode-switch">
-					<input type="checkbox" class="dark-mode-switch-input" id="dark-mode-switch" aria-label="Toggle dark mode">
+					<input type="checkbox" class="dark-mode-switch-input" id="dark-mode-switch" aria-label="Toggle dark mode"/>
 					<label class="dark-mode-switch-label" for="dark-mode-switch">
 						<span class="dark-mode-switch-indicator"></span>
 					</label>
@@ -58,7 +186,7 @@ templ Base(activePage string) {
 				<p class="banner-subtitle">Tim's interests</p>
 			</header>
 			<nav class="nav-header" aria-label="Main navigation">
-				<input type="checkbox" id="nav-toggle" class="nav-toggle-input" aria-label="Toggle navigation menu" />
+				<input type="checkbox" id="nav-toggle" class="nav-toggle-input" aria-label="Toggle navigation menu"/>
 				<label for="nav-toggle" class="nav-toggle-label" aria-hidden="true"><i class="fa-solid fa-bars"></i></label>
 				<div class="nav-links">
 					<a href="/home" class={ "nav-link", templ.KV("active", activePage == "home") }><i class="fa-solid fa-house" aria-hidden="true"></i> Home</a>

--- a/cmd/web/projects.go
+++ b/cmd/web/projects.go
@@ -78,7 +78,7 @@ func GetProjectHandler(w http.ResponseWriter, r *http.Request, s storage.Storage
 
 				component = ProjectDisplay(dc, project.Repository, project.Timespan(), authenticated)
 			} else {
-				component = ProjectPage(dc, project.Repository, project.Timespan(), authenticated)
+				component = ProjectPage(project, dc, project.Repository, project.Timespan(), authenticated)
 			}
 
 			err = renderHTML(w, r, http.StatusOK, component)

--- a/cmd/web/projects.templ
+++ b/cmd/web/projects.templ
@@ -5,6 +5,14 @@ import (
     "timterests/internal/model"
 )
 
+func projectDescription(p model.Project) string {
+	if p.Subtitle != "" {
+		return p.Subtitle
+	}
+
+	return p.Preview
+}
+
 templ ProjectsListPage(projects []model.Project, tags []string, design string) {
 	@Base("projects") {
 		<div id="projects-container">
@@ -46,10 +54,14 @@ templ ProjectsList(projects []model.Project, design string) {
 	</ul>
 }
 
-templ ProjectPage(dc model.DisplayContent, repository string, timespan string, userIsAdmin bool) {
-    @Base("projects") {
-        @ProjectDisplay(dc, repository, timespan, userIsAdmin)
-    }
+templ ProjectPage(project model.Project, dc model.DisplayContent, repository string, timespan string, userIsAdmin bool) {
+	@Base("projects", MetaProps{
+		Description: projectDescription(project),
+		Title:       project.Title + " | Timterests",
+		URL:         "/project?id=" + project.ID,
+	}) {
+		@ProjectDisplay(dc, repository, timespan, userIsAdmin)
+	}
 }
 
 templ ProjectDisplay(dc model.DisplayContent, repository string, timespan string, userIsAdmin bool) {

--- a/cmd/web/seo.go
+++ b/cmd/web/seo.go
@@ -1,0 +1,125 @@
+package web
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"timterests/internal/service"
+	"timterests/internal/storage"
+)
+
+type urlSet struct {
+	XMLName xml.Name  `xml:"urlset"`
+	XMLNS   string    `xml:"xmlns,attr"`
+	URLs    []siteURL `xml:"url"`
+}
+
+type siteURL struct {
+	Loc        string `xml:"loc"`
+	LastMod    string `xml:"lastmod,omitempty"`
+	ChangeFreq string `xml:"changefreq,omitempty"`
+	Priority   string `xml:"priority,omitempty"`
+}
+
+func siteBaseURL() string {
+	if u := os.Getenv("SITE_URL"); u != "" {
+		return strings.TrimRight(u, "/")
+	}
+
+	return "https://timterests.com"
+}
+
+// RobotsHandler serves robots.txt.
+func RobotsHandler(w http.ResponseWriter, _ *http.Request) {
+	baseURL := siteBaseURL()
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+
+	fmt.Fprintf(w, "User-agent: *\n")
+	fmt.Fprintf(w, "Allow: /\n")
+	fmt.Fprintf(w, "Disallow: /admin\n")
+	fmt.Fprintf(w, "Disallow: /writer\n")
+	fmt.Fprintf(w, "Disallow: /login\n")
+	fmt.Fprintf(w, "Disallow: /download\n")
+	fmt.Fprintf(w, "\n")
+	fmt.Fprintf(w, "Sitemap: %s/sitemap.xml\n", baseURL)
+}
+
+// SitemapHandler generates and serves sitemap.xml.
+func SitemapHandler(w http.ResponseWriter, r *http.Request, s storage.Storage) {
+	baseURL := siteBaseURL()
+	now := time.Now().Format("2006-01-02")
+
+	urls := []siteURL{
+		{Loc: baseURL + "/", Priority: "1.0", ChangeFreq: "weekly", LastMod: now},
+		{Loc: baseURL + "/articles", Priority: "0.9", ChangeFreq: "weekly", LastMod: now},
+		{Loc: baseURL + "/projects", Priority: "0.9", ChangeFreq: "monthly", LastMod: now},
+		{Loc: baseURL + "/reading-list", Priority: "0.7", ChangeFreq: "monthly", LastMod: now},
+		{Loc: baseURL + "/about", Priority: "0.8", ChangeFreq: "monthly", LastMod: now},
+	}
+
+	articles, err := service.ListArticles(r.Context(), s, "all")
+	if err != nil {
+		log.Printf("SitemapHandler: failed to list articles: %v", err)
+	}
+
+	for _, a := range articles {
+		urls = append(urls, siteURL{
+			Loc:        baseURL + "/article?id=" + a.ID,
+			LastMod:    a.Date,
+			ChangeFreq: "yearly",
+			Priority:   "0.8",
+		})
+	}
+
+	projects, err := service.ListProjects(r.Context(), s, "all")
+	if err != nil {
+		log.Printf("SitemapHandler: failed to list projects: %v", err)
+	}
+
+	for _, p := range projects {
+		urls = append(urls, siteURL{
+			Loc:        baseURL + "/project?id=" + p.ID,
+			ChangeFreq: "monthly",
+			Priority:   "0.7",
+		})
+	}
+
+	books, err := service.ListBooks(r.Context(), s, "all")
+	if err != nil {
+		log.Printf("SitemapHandler: failed to list books: %v", err)
+	}
+
+	for _, b := range books {
+		urls = append(urls, siteURL{
+			Loc:        baseURL + "/book?id=" + b.ID,
+			ChangeFreq: "yearly",
+			Priority:   "0.5",
+		})
+	}
+
+	sitemap := urlSet{
+		XMLNS: "http://www.sitemaps.org/schemas/sitemap/0.9",
+		URLs:  urls,
+	}
+
+	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
+
+	if _, err := w.Write([]byte(xml.Header)); err != nil {
+		log.Printf("SitemapHandler: failed to write XML header: %v", err)
+
+		return
+	}
+
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "  ")
+
+	if err := enc.Encode(sitemap); err != nil {
+		log.Printf("SitemapHandler: failed to encode sitemap: %v", err)
+	}
+}

--- a/cmd/web/seo.go
+++ b/cmd/web/seo.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
-	"strings"
 	"time"
 
 	"timterests/internal/service"
@@ -14,48 +12,41 @@ import (
 )
 
 type urlSet struct {
-	XMLName xml.Name  `xml:"urlset"`
-	XMLNS   string    `xml:"xmlns,attr"`
-	URLs    []siteURL `xml:"url"`
+	XMLName xml.Name     `xml:"urlset"`
+	XMLNS   string       `xml:"xmlns,attr"`
+	URLs    []sitemapURL `xml:"url"`
 }
 
-type siteURL struct {
+type sitemapURL struct {
 	Loc        string `xml:"loc"`
 	LastMod    string `xml:"lastmod,omitempty"`
 	ChangeFreq string `xml:"changefreq,omitempty"`
 	Priority   string `xml:"priority,omitempty"`
 }
 
-func siteBaseURL() string {
-	if u := os.Getenv("SITE_URL"); u != "" {
-		return strings.TrimRight(u, "/")
-	}
-
-	return "https://timterests.com"
-}
-
 // RobotsHandler serves robots.txt.
 func RobotsHandler(w http.ResponseWriter, _ *http.Request) {
-	baseURL := siteBaseURL()
+	baseURL := siteURL()
 
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 
-	fmt.Fprintf(w, "User-agent: *\n")
-	fmt.Fprintf(w, "Allow: /\n")
-	fmt.Fprintf(w, "Disallow: /admin\n")
-	fmt.Fprintf(w, "Disallow: /writer\n")
-	fmt.Fprintf(w, "Disallow: /login\n")
-	fmt.Fprintf(w, "Disallow: /download\n")
-	fmt.Fprintf(w, "\n")
-	fmt.Fprintf(w, "Sitemap: %s/sitemap.xml\n", baseURL)
+	body := fmt.Sprintf(
+		"User-agent: *\nAllow: /\nDisallow: /admin\nDisallow: /writer\nDisallow: /login\nDisallow: /download\n\nSitemap: %s/sitemap.xml\n",
+		baseURL,
+	)
+
+	_, err := w.Write([]byte(body))
+	if err != nil {
+		log.Printf("RobotsHandler: failed to write response: %v", err)
+	}
 }
 
 // SitemapHandler generates and serves sitemap.xml.
 func SitemapHandler(w http.ResponseWriter, r *http.Request, s storage.Storage) {
-	baseURL := siteBaseURL()
+	baseURL := siteURL()
 	now := time.Now().Format("2006-01-02")
 
-	urls := []siteURL{
+	staticPages := []sitemapURL{
 		{Loc: baseURL + "/", Priority: "1.0", ChangeFreq: "weekly", LastMod: now},
 		{Loc: baseURL + "/articles", Priority: "0.9", ChangeFreq: "weekly", LastMod: now},
 		{Loc: baseURL + "/projects", Priority: "0.9", ChangeFreq: "monthly", LastMod: now},
@@ -68,26 +59,9 @@ func SitemapHandler(w http.ResponseWriter, r *http.Request, s storage.Storage) {
 		log.Printf("SitemapHandler: failed to list articles: %v", err)
 	}
 
-	for _, a := range articles {
-		urls = append(urls, siteURL{
-			Loc:        baseURL + "/article?id=" + a.ID,
-			LastMod:    a.Date,
-			ChangeFreq: "yearly",
-			Priority:   "0.8",
-		})
-	}
-
 	projects, err := service.ListProjects(r.Context(), s, "all")
 	if err != nil {
 		log.Printf("SitemapHandler: failed to list projects: %v", err)
-	}
-
-	for _, p := range projects {
-		urls = append(urls, siteURL{
-			Loc:        baseURL + "/project?id=" + p.ID,
-			ChangeFreq: "monthly",
-			Priority:   "0.7",
-		})
 	}
 
 	books, err := service.ListBooks(r.Context(), s, "all")
@@ -95,8 +69,28 @@ func SitemapHandler(w http.ResponseWriter, r *http.Request, s storage.Storage) {
 		log.Printf("SitemapHandler: failed to list books: %v", err)
 	}
 
+	urls := make([]sitemapURL, 0, len(staticPages)+len(articles)+len(projects)+len(books))
+	urls = append(urls, staticPages...)
+
+	for _, a := range articles {
+		urls = append(urls, sitemapURL{
+			Loc:        baseURL + "/article?id=" + a.ID,
+			LastMod:    a.Date,
+			ChangeFreq: "yearly",
+			Priority:   "0.8",
+		})
+	}
+
+	for _, p := range projects {
+		urls = append(urls, sitemapURL{
+			Loc:        baseURL + "/project?id=" + p.ID,
+			ChangeFreq: "monthly",
+			Priority:   "0.7",
+		})
+	}
+
 	for _, b := range books {
-		urls = append(urls, siteURL{
+		urls = append(urls, sitemapURL{
 			Loc:        baseURL + "/book?id=" + b.ID,
 			ChangeFreq: "yearly",
 			Priority:   "0.5",
@@ -110,7 +104,8 @@ func SitemapHandler(w http.ResponseWriter, r *http.Request, s storage.Storage) {
 
 	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
 
-	if _, err := w.Write([]byte(xml.Header)); err != nil {
+	_, err = w.Write([]byte(xml.Header))
+	if err != nil {
 		log.Printf("SitemapHandler: failed to write XML header: %v", err)
 
 		return
@@ -119,7 +114,8 @@ func SitemapHandler(w http.ResponseWriter, r *http.Request, s storage.Storage) {
 	enc := xml.NewEncoder(w)
 	enc.Indent("", "  ")
 
-	if err := enc.Encode(sitemap); err != nil {
+	err = enc.Encode(sitemap)
+	if err != nil {
 		log.Printf("SitemapHandler: failed to encode sitemap: %v", err)
 	}
 }

--- a/cmd/web/seo.go
+++ b/cmd/web/seo.go
@@ -30,10 +30,14 @@ func RobotsHandler(w http.ResponseWriter, _ *http.Request) {
 
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 
-	body := fmt.Sprintf(
-		"User-agent: *\nAllow: /\nDisallow: /admin\nDisallow: /writer\nDisallow: /login\nDisallow: /download\n\nSitemap: %s/sitemap.xml\n",
-		baseURL,
-	)
+	body := "User-agent: *\n" +
+		"Allow: /\n" +
+		"Disallow: /admin\n" +
+		"Disallow: /writer\n" +
+		"Disallow: /login\n" +
+		"Disallow: /download\n" +
+		"\n" +
+		fmt.Sprintf("Sitemap: %s/sitemap.xml\n", baseURL)
 
 	_, err := w.Write([]byte(body))
 	if err != nil {

--- a/cmd/web/seo_test.go
+++ b/cmd/web/seo_test.go
@@ -1,0 +1,85 @@
+package web_test
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"timterests/cmd/web"
+)
+
+func TestRobotsHandler(t *testing.T) {
+	t.Setenv("SITE_URL", "https://example.com")
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/robots.txt", nil)
+	rec := httptest.NewRecorder()
+
+	web.RobotsHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	body := rec.Body.String()
+
+	for _, want := range []string{
+		"User-agent: *",
+		"Disallow: /admin",
+		"Disallow: /writer",
+		"Disallow: /login",
+		"Disallow: /download",
+		"Sitemap: https://example.com/sitemap.xml",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("robots.txt missing %q", want)
+		}
+	}
+}
+
+func TestSitemapHandler(t *testing.T) {
+	s := testSetup(t, context.Background())
+	t.Setenv("SITE_URL", "https://example.com")
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/sitemap.xml", nil)
+	rec := httptest.NewRecorder()
+
+	web.SitemapHandler(rec, req, *s)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	ct := rec.Header().Get("Content-Type")
+	if !strings.Contains(ct, "application/xml") {
+		t.Errorf("expected XML content type, got %q", ct)
+	}
+
+	var result struct {
+		XMLName xml.Name `xml:"urlset"`
+		URLs    []struct {
+			Loc string `xml:"loc"`
+		} `xml:"url"`
+	}
+
+	if err := xml.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to parse sitemap XML: %v", err)
+	}
+
+	if len(result.URLs) < 5 {
+		t.Errorf("expected at least 5 URLs in sitemap (static pages), got %d", len(result.URLs))
+	}
+
+	hasRoot := false
+	for _, u := range result.URLs {
+		if u.Loc == "https://example.com/" {
+			hasRoot = true
+		}
+	}
+
+	if !hasRoot {
+		t.Error("sitemap missing root URL")
+	}
+}

--- a/cmd/web/seo_test.go
+++ b/cmd/web/seo_test.go
@@ -64,7 +64,8 @@ func TestSitemapHandler(t *testing.T) {
 		} `xml:"url"`
 	}
 
-	if err := xml.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+	err := xml.Unmarshal(rec.Body.Bytes(), &result)
+	if err != nil {
 		t.Fatalf("failed to parse sitemap XML: %v", err)
 	}
 
@@ -73,6 +74,7 @@ func TestSitemapHandler(t *testing.T) {
 	}
 
 	hasRoot := false
+
 	for _, u := range result.URLs {
 		if u.Loc == "https://example.com/" {
 			hasRoot = true
@@ -81,5 +83,33 @@ func TestSitemapHandler(t *testing.T) {
 
 	if !hasRoot {
 		t.Error("sitemap missing root URL")
+	}
+}
+
+func TestMetaTagsRendered(t *testing.T) {
+	s := testSetup(t, context.Background())
+	t.Setenv("SITE_URL", "https://example.com")
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/about", nil)
+	rec := httptest.NewRecorder()
+
+	web.AboutHandler(rec, req, *s)
+
+	body := rec.Body.String()
+
+	for _, want := range []string{
+		`name="description"`,
+		`property="og:title"`,
+		`property="og:description"`,
+		`property="og:type"`,
+		`property="og:image"`,
+		`name="twitter:card"`,
+		`name="twitter:title"`,
+		`rel="canonical"`,
+		`href="https://example.com/about"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("about page missing meta tag containing %q", want)
+		}
 	}
 }

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -106,6 +106,12 @@ func (s *Server) RegisterRoutes() http.Handler {
 		web.DownloadNewDocumentHandler(w, r, s.auth)
 	}))
 
+	// SEO
+	mux.HandleFunc("/robots.txt", web.RobotsHandler)
+	mux.Handle("/sitemap.xml", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		web.SitemapHandler(w, r, *s.Storage)
+	}))
+
 	// Health check
 	mux.HandleFunc("/health", s.HealthHandler)
 


### PR DESCRIPTION
## Summary
Expands the initial page titles PR into a full SEO foundation (closes #166):

- **Dynamic page titles** — each page shows a descriptive browser tab title (e.g. "Articles | Timterests")
- **Meta descriptions** — unique per-page descriptions for search engine snippets
- **Open Graph tags** — `og:title`, `og:description`, `og:type`, `og:image`, `og:url` on every page
- **Twitter Card tags** — rich preview cards for social shares
- **Canonical URLs** — `<link rel="canonical">` prevents duplicate content issues (requires `SITE_URL` env var)
- **robots.txt** — blocks `/admin`, `/writer`, `/login`, `/download` from crawlers; includes sitemap URL
- **sitemap.xml** — dynamically generated from all articles, projects, and reading list items with priority weights
- **JSON-LD structured data** — Organization schema on home, Person schema on about, Article schema on article detail pages
- **Per-page MetaProps** — article and project detail pages pass content-specific metadata (description, type, URL, JSON-LD)

No external dependencies — uses Go stdlib `encoding/xml` and `encoding/json`.

## Test plan
- [ ] Verify browser tab titles on each page
- [ ] Verify `/robots.txt` returns correct directives and sitemap URL
- [ ] Verify `/sitemap.xml` returns valid XML with all content URLs
- [ ] Verify meta description, OG, and Twitter tags in page source
- [ ] Verify canonical URL renders when `SITE_URL` env var is set
- [ ] View page source on article detail — confirm Article JSON-LD schema
- [ ] All existing tests pass (`make test`)