### PR TITLE
feat: mobile experience follow-up — layout fixes and nav close

### DIFF
--- a/cmd/web/assets/css/styles.css
+++ b/cmd/web/assets/css/styles.css
@@ -1383,4 +1383,66 @@ a:hover {
     margin-left: 0;
     margin-top: 0.5rem;
   }
+
+  .about-tabs {
+    flex-wrap: wrap;
+    gap: 0;
+  }
+
+  .tab-btn {
+    flex: 1 1 auto;
+    text-align: center;
+    padding: 0.5rem 0.5rem;
+    font-size: 0.8125rem;
+    min-height: 44px;
+  }
+
+  .admin-table th:nth-child(n + 3),
+  .admin-table td:nth-child(n + 3) {
+    display: none;
+  }
+
+  .about-profile {
+    padding: 1rem;
+  }
+
+  .timeline-container {
+    padding-left: 1rem;
+    margin-left: 0;
+  }
+}
+
+/* Code block overflow */
+pre {
+  overflow-x: auto;
+  max-width: 100%;
+  padding: 1rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+code {
+  font-size: 0.875em;
+}
+
+pre code {
+  white-space: pre;
+}
+
+/* Tablet breakpoint */
+@media (min-width: 768px) and (max-width: 1023px) {
+  .card-container,
+  .card-container-static {
+    flex-direction: row;
+  }
+
+  .card-image {
+    width: 200px;
+    flex-shrink: 0;
+  }
+
+  .section-grid-3 {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }

--- a/cmd/web/assets/css/styles.css
+++ b/cmd/web/assets/css/styles.css
@@ -1397,8 +1397,8 @@ a:hover {
     min-height: 44px;
   }
 
-  .admin-table th:nth-child(n + 3),
-  .admin-table td:nth-child(n + 3) {
+  .admin-table th:nth-child(n + 3):not(:last-child),
+  .admin-table td:nth-child(n + 3):not(:last-child) {
     display: none;
   }
 

--- a/cmd/web/assets/js/buttons.js
+++ b/cmd/web/assets/js/buttons.js
@@ -7,3 +7,10 @@ function setActiveTab(button) {
     document.querySelectorAll('.tab-btn').forEach(btn => btn.classList.remove('active'));
     button.classList.add('active');
 }
+
+document.body.addEventListener('htmx:afterSwap', function () {
+    var toggle = document.getElementById('nav-toggle');
+    if (toggle) {
+        toggle.checked = false;
+    }
+});

--- a/cmd/web/assets/js/buttons.js
+++ b/cmd/web/assets/js/buttons.js
@@ -8,9 +8,11 @@ function setActiveTab(button) {
     button.classList.add('active');
 }
 
-document.body.addEventListener('htmx:afterSwap', function () {
-    var toggle = document.getElementById('nav-toggle');
-    if (toggle) {
-        toggle.checked = false;
+document.body.addEventListener('htmx:afterSwap', function (evt) {
+    if (evt.detail.target.id === 'main-content') {
+        var toggle = document.getElementById('nav-toggle');
+        if (toggle) {
+            toggle.checked = false;
+        }
     }
 });


### PR DESCRIPTION
## Summary
Addresses the CSS and interaction issues from #165:

- **Code block overflow** — `pre` elements now scroll horizontally on narrow screens instead of breaking layout
- **About page tabs** — flex-wrap with auto-sizing so tabs fit on mobile without breaking; 44px min touch targets
- **Admin table responsive** — hides columns 3+ on mobile, keeping title and type visible in the scrollable wrapper
- **Hamburger nav auto-close** — `htmx:afterSwap` listener unchecks the nav toggle after content swap, preventing "stuck open" menu
- **Tablet breakpoint** — 768-1024px gets horizontal card layout and 2-column grids
- **Tighter mobile spacing** — timeline and profile components use less padding on small screens

Remaining items from #165 that need separate work or Nick's input:
- Reading list detail mobile layout (needs visual review)
- Filter dropdowns mobile verification
- Open/closed state icon on hamburger (design decision)

Closes #165

## Test plan
- [ ] Resize browser to mobile width — verify code blocks scroll horizontally
- [ ] About page tabs wrap cleanly on narrow screens
- [ ] Admin documents table hides extra columns on mobile
- [ ] Navigate via hamburger menu on mobile — menu closes after each link
- [ ] Tablet width (768-1024px) shows cards in horizontal layout
- [ ] All existing tests pass