### PR TITLE
feat: add RSS feed for articles

### DIFF
--- a/cmd/web/base.templ
+++ b/cmd/web/base.templ
@@ -170,6 +170,7 @@ templ Base(activePage string, metas ...MetaProps) {
 			<link href="/assets/css/dark-mode-switch.css" rel="stylesheet"/>
 			<link href="/assets/css/styles.css" rel="stylesheet"/>
 			<link rel="icon" type="image/png" href="/assets/images/favicon.png"/>
+			<link rel="alternate" type="application/rss+xml" title={ Site().Name + " RSS Feed" } href="/rss.xml"/>
 		</head>
 		<body>
 			<a href="#main-content" class="skip-link">Skip to content</a>

--- a/cmd/web/download.go
+++ b/cmd/web/download.go
@@ -99,6 +99,7 @@ func DownloadNewDocumentHandler(w http.ResponseWriter, r *http.Request, a *auth.
 		}
 	}()
 
+	// #nosec G705 -- writing to a temp file, not an HTTP response; no XSS risk
 	_, err = fmt.Fprintf(f, "# %s\n## %s\n\n%s", title, subtitle, body)
 
 	closeErr := f.Close()

--- a/cmd/web/rss.go
+++ b/cmd/web/rss.go
@@ -57,8 +57,8 @@ func RSSHandler(
 		}
 
 		pubDate := a.Date
-		t, err := time.Parse("2006-01-02", a.Date)
 
+		t, err := time.Parse("2006-01-02", a.Date)
 		if err == nil {
 			pubDate = t.Format(time.RFC1123Z)
 		}

--- a/cmd/web/rss.go
+++ b/cmd/web/rss.go
@@ -57,7 +57,8 @@ func RSSHandler(
 		}
 
 		pubDate := a.Date
-		if t, err := time.Parse("2006-01-02", a.Date); err == nil {
+		t, err := time.Parse("2006-01-02", a.Date)
+		if err == nil {
 			pubDate = t.Format(time.RFC1123Z)
 		}
 

--- a/cmd/web/rss.go
+++ b/cmd/web/rss.go
@@ -58,6 +58,7 @@ func RSSHandler(
 
 		pubDate := a.Date
 		t, err := time.Parse("2006-01-02", a.Date)
+
 		if err == nil {
 			pubDate = t.Format(time.RFC1123Z)
 		}

--- a/cmd/web/rss.go
+++ b/cmd/web/rss.go
@@ -59,7 +59,8 @@ func RSSHandler(
 
 		var pubDate string
 
-		if t, err := time.Parse("2006-01-02", a.Date); err == nil {
+		t, err := time.Parse("2006-01-02", a.Date)
+		if err == nil {
 			pubDate = t.Format(time.RFC1123Z)
 		}
 

--- a/cmd/web/rss.go
+++ b/cmd/web/rss.go
@@ -1,0 +1,94 @@
+package web
+
+import (
+	"encoding/xml"
+	"log"
+	"net/http"
+
+	"timterests/internal/service"
+	"timterests/internal/storage"
+)
+
+type rssChannel struct {
+	Title       string    `xml:"title"`
+	Link        string    `xml:"link"`
+	Description string    `xml:"description"`
+	Language    string    `xml:"language"`
+	Items       []rssItem `xml:"item"`
+}
+
+type rssFeed struct {
+	XMLName xml.Name   `xml:"rss"`
+	Version string     `xml:"version,attr"`
+	Channel rssChannel `xml:"channel"`
+}
+
+type rssItem struct {
+	Title       string `xml:"title"`
+	Link        string `xml:"link"`
+	Description string `xml:"description"`
+	PubDate     string `xml:"pubDate,omitempty"`
+	GUID        string `xml:"guid"`
+}
+
+// RSSHandler generates and serves an RSS 2.0 feed of articles.
+func RSSHandler(
+	w http.ResponseWriter,
+	r *http.Request,
+	s storage.Storage,
+) {
+	baseURL := Site().URL
+
+	articles, err := service.ListArticles(r.Context(), s, "all")
+	if err != nil {
+		log.Printf("RSSHandler: failed to list articles: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+
+		return
+	}
+
+	items := make([]rssItem, 0, len(articles))
+
+	for _, a := range articles {
+		desc := a.Subtitle
+		if desc == "" {
+			desc = a.Preview
+		}
+
+		items = append(items, rssItem{
+			Title:       a.Title,
+			Link:        baseURL + "/article?id=" + a.ID,
+			Description: desc,
+			PubDate:     a.Date,
+			GUID:        baseURL + "/article?id=" + a.ID,
+		})
+	}
+
+	feed := rssFeed{
+		Version: "2.0",
+		Channel: rssChannel{
+			Title:       Site().Name,
+			Link:        baseURL,
+			Description: Site().Description,
+			Language:    "en",
+			Items:       items,
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/rss+xml; charset=utf-8")
+
+	_, err = w.Write([]byte(xml.Header))
+	if err != nil {
+		log.Printf("RSSHandler: failed to write XML header: %v", err)
+
+		return
+	}
+
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "  ")
+
+	err = enc.Encode(feed)
+	if err != nil {
+		log.Printf("RSSHandler: failed to encode RSS feed: %v", err)
+	}
+}

--- a/cmd/web/rss.go
+++ b/cmd/web/rss.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"log"
 	"net/http"
+	"time"
 
 	"timterests/internal/service"
 	"timterests/internal/storage"
@@ -55,11 +56,16 @@ func RSSHandler(
 			desc = a.Preview
 		}
 
+		pubDate := a.Date
+		if t, err := time.Parse("2006-01-02", a.Date); err == nil {
+			pubDate = t.Format(time.RFC1123Z)
+		}
+
 		items = append(items, rssItem{
 			Title:       a.Title,
 			Link:        baseURL + "/article?id=" + a.ID,
 			Description: desc,
-			PubDate:     a.Date,
+			PubDate:     pubDate,
 			GUID:        baseURL + "/article?id=" + a.ID,
 		})
 	}

--- a/cmd/web/rss.go
+++ b/cmd/web/rss.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"timterests/internal/service"
@@ -38,7 +39,7 @@ func RSSHandler(
 	r *http.Request,
 	s storage.Storage,
 ) {
-	baseURL := Site().URL
+	baseURL := strings.TrimRight(Site().URL, "/")
 
 	articles, err := service.ListArticles(r.Context(), s, "all")
 	if err != nil {
@@ -56,10 +57,9 @@ func RSSHandler(
 			desc = a.Preview
 		}
 
-		pubDate := a.Date
+		var pubDate string
 
-		t, err := time.Parse("2006-01-02", a.Date)
-		if err == nil {
+		if t, err := time.Parse("2006-01-02", a.Date); err == nil {
 			pubDate = t.Format(time.RFC1123Z)
 		}
 

--- a/cmd/web/rss.go
+++ b/cmd/web/rss.go
@@ -39,7 +39,7 @@ func RSSHandler(
 	r *http.Request,
 	s storage.Storage,
 ) {
-    site := Site()
+	site := Site()
 	baseURL := strings.TrimRight(site.URL, "/")
 
 	articles, err := service.ListArticles(r.Context(), s, "all")

--- a/cmd/web/rss.go
+++ b/cmd/web/rss.go
@@ -39,7 +39,8 @@ func RSSHandler(
 	r *http.Request,
 	s storage.Storage,
 ) {
-	baseURL := strings.TrimRight(Site().URL, "/")
+    site := Site()
+	baseURL := strings.TrimRight(site.URL, "/")
 
 	articles, err := service.ListArticles(r.Context(), s, "all")
 	if err != nil {
@@ -76,9 +77,9 @@ func RSSHandler(
 	feed := rssFeed{
 		Version: "2.0",
 		Channel: rssChannel{
-			Title:       Site().Name,
+			Title:       site.Name,
 			Link:        baseURL,
-			Description: Site().Description,
+			Description: site.Description,
 			Language:    "en",
 			Items:       items,
 		},

--- a/cmd/web/rss_test.go
+++ b/cmd/web/rss_test.go
@@ -80,9 +80,30 @@ func TestRSSHandler(t *testing.T) {
 			t.Errorf("RSS item link missing base URL: %q", item.Link)
 		}
 
+		if strings.Contains(item.Link, "//article") {
+			t.Errorf("RSS item link has double slash: %q", item.Link)
+		}
+
 		_, err := time.Parse(time.RFC1123Z, item.PubDate)
 		if err != nil {
-			t.Errorf("RSS item pubDate %q is not valid RFC 822: %v", item.PubDate, err)
+			t.Errorf("RSS item pubDate %q is not valid RFC1123Z: %v", item.PubDate, err)
 		}
+	}
+}
+
+func TestRSSHandlerTrailingSlash(t *testing.T) {
+	s := testSetup(t, context.Background())
+	t.Setenv("SITE_URL", "https://example.com/")
+
+	req := httptest.NewRequestWithContext(
+		context.Background(), http.MethodGet, "/rss.xml", nil,
+	)
+	rec := httptest.NewRecorder()
+
+	web.RSSHandler(rec, req, *s)
+
+	body := rec.Body.String()
+	if strings.Contains(body, "https://example.com//") {
+		t.Error("trailing slash on SITE_URL produced double slashes in feed URLs")
 	}
 }

--- a/cmd/web/rss_test.go
+++ b/cmd/web/rss_test.go
@@ -80,7 +80,8 @@ func TestRSSHandler(t *testing.T) {
 			t.Errorf("RSS item link missing base URL: %q", item.Link)
 		}
 
-		if _, err := time.Parse(time.RFC1123Z, item.PubDate); err != nil {
+		_, err := time.Parse(time.RFC1123Z, item.PubDate)
+		if err != nil {
 			t.Errorf("RSS item pubDate %q is not valid RFC 822: %v", item.PubDate, err)
 		}
 	}

--- a/cmd/web/rss_test.go
+++ b/cmd/web/rss_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"timterests/cmd/web"
 )
@@ -39,9 +40,10 @@ func TestRSSHandler(t *testing.T) {
 			Title string `xml:"title"`
 			Link  string `xml:"link"`
 			Items []struct {
-				Title string `xml:"title"`
-				Link  string `xml:"link"`
-				GUID  string `xml:"guid"`
+				Title   string `xml:"title"`
+				Link    string `xml:"link"`
+				GUID    string `xml:"guid"`
+				PubDate string `xml:"pubDate"`
 			} `xml:"item"`
 		} `xml:"channel"`
 	}
@@ -65,6 +67,10 @@ func TestRSSHandler(t *testing.T) {
 			"https://example.com", result.Channel.Link)
 	}
 
+	if len(result.Channel.Items) == 0 {
+		t.Fatal("expected at least one item, got none")
+	}
+
 	for _, item := range result.Channel.Items {
 		if item.Title == "" {
 			t.Error("RSS item has empty title")
@@ -72,6 +78,10 @@ func TestRSSHandler(t *testing.T) {
 
 		if !strings.HasPrefix(item.Link, "https://example.com/") {
 			t.Errorf("RSS item link missing base URL: %q", item.Link)
+		}
+
+		if _, err := time.Parse(time.RFC1123Z, item.PubDate); err != nil {
+			t.Errorf("RSS item pubDate %q is not valid RFC 822: %v", item.PubDate, err)
 		}
 	}
 }

--- a/cmd/web/rss_test.go
+++ b/cmd/web/rss_test.go
@@ -1,0 +1,77 @@
+package web_test
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"timterests/cmd/web"
+)
+
+func TestRSSHandler(t *testing.T) {
+	s := testSetup(t, context.Background())
+	t.Setenv("SITE_URL", "https://example.com")
+	t.Setenv("SITE_NAME", "TestBlog")
+
+	req := httptest.NewRequestWithContext(
+		context.Background(), http.MethodGet, "/rss.xml", nil,
+	)
+	rec := httptest.NewRecorder()
+
+	web.RSSHandler(rec, req, *s)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	ct := rec.Header().Get("Content-Type")
+	if !strings.Contains(ct, "application/rss+xml") {
+		t.Errorf("expected rss+xml content type, got %q", ct)
+	}
+
+	var result struct {
+		XMLName xml.Name `xml:"rss"`
+		Version string   `xml:"version,attr"`
+		Channel struct {
+			Title string `xml:"title"`
+			Link  string `xml:"link"`
+			Items []struct {
+				Title string `xml:"title"`
+				Link  string `xml:"link"`
+				GUID  string `xml:"guid"`
+			} `xml:"item"`
+		} `xml:"channel"`
+	}
+
+	err := xml.Unmarshal(rec.Body.Bytes(), &result)
+	if err != nil {
+		t.Fatalf("failed to parse RSS XML: %v", err)
+	}
+
+	if result.Version != "2.0" {
+		t.Errorf("expected RSS version 2.0, got %q", result.Version)
+	}
+
+	if result.Channel.Title != "TestBlog" {
+		t.Errorf("expected channel title %q, got %q",
+			"TestBlog", result.Channel.Title)
+	}
+
+	if result.Channel.Link != "https://example.com" {
+		t.Errorf("expected channel link %q, got %q",
+			"https://example.com", result.Channel.Link)
+	}
+
+	for _, item := range result.Channel.Items {
+		if item.Title == "" {
+			t.Error("RSS item has empty title")
+		}
+
+		if !strings.HasPrefix(item.Link, "https://example.com/") {
+			t.Errorf("RSS item link missing base URL: %q", item.Link)
+		}
+	}
+}

--- a/cmd/web/rss_test.go
+++ b/cmd/web/rss_test.go
@@ -84,9 +84,11 @@ func TestRSSHandler(t *testing.T) {
 			t.Errorf("RSS item link has double slash: %q", item.Link)
 		}
 
-		_, err := time.Parse(time.RFC1123Z, item.PubDate)
-		if err != nil {
-			t.Errorf("RSS item pubDate %q is not valid RFC1123Z: %v", item.PubDate, err)
+		if item.PubDate != "" {
+			_, err := time.Parse(time.RFC1123Z, item.PubDate)
+			if err != nil {
+				t.Errorf("RSS item pubDate %q is not valid RFC1123Z: %v", item.PubDate, err)
+			}
 		}
 	}
 }

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -111,6 +111,9 @@ func (s *Server) RegisterRoutes() http.Handler {
 	mux.Handle("/sitemap.xml", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		web.SitemapHandler(w, r, *s.Storage)
 	}))
+	mux.Handle("/rss.xml", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		web.RSSHandler(w, r, *s.Storage)
+	}))
 
 	// Health check
 	mux.HandleFunc("/health", s.HealthHandler)


### PR DESCRIPTION
## Summary
- Adds `/rss.xml` endpoint serving RSS 2.0 feed of all articles
- RSS autodiscovery `<link>` tag in `<head>` for browser/reader detection
- Uses `Site()` config for feed title, link, and description
- Articles include title, permalink, description (subtitle or preview), and publish date

## Test plan
- [x] Build passes, 0 lint issues
- [x] All existing tests pass
- [x] `TestRSSHandler` verifies XML structure, version, channel metadata, and item links
- [ ] Manual: verify feed validates at a feed validator
- [ ] Manual: verify autodiscovery works in a browser