### PR TITLE
feat: add reading time estimates to article pages

### DIFF
--- a/cmd/web/articles.templ
+++ b/cmd/web/articles.templ
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"timterests/cmd/web/components"
 	"timterests/internal/model"
+	"timterests/internal/storage"
 )
 
 func articleDescription(a model.Article) string {
@@ -92,6 +93,7 @@ templ ArticleDisplay(dc model.DisplayContent, userIsAdmin bool) {
     @EditArticleButton(dc, userIsAdmin)
     @components.DownloadDocumentButton(dc.S3Key, userIsAdmin)
 	<div id="article-container">
+		<p class="card-date">{ storage.ReadingTime(dc.Body) }</p>
 		@templ.Raw(dc.Body)
 	</div>
 }

--- a/cmd/web/articles_test.go
+++ b/cmd/web/articles_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"timterests/cmd/web"
 	"timterests/internal/auth"
@@ -156,6 +157,16 @@ func TestArticleRendering(t *testing.T) {
 		if doc.Find("h2").Length() == 0 {
 			t.Error("expected h2 element to be rendered, but it wasn't")
 		}
+
+		// Expect the reading time estimate to be present and formatted correctly.
+		readingTime := doc.Find("#article-container p.card-date").First().Text()
+		if readingTime == "" {
+			t.Error("expected reading time element to be rendered, but it wasn't")
+		}
+
+		if !strings.HasSuffix(readingTime, " min read") {
+			t.Errorf("expected reading time to match \"X min read\", got %q", readingTime)
+		}
 	})
 
 	t.Run("render article display only", func(t *testing.T) {
@@ -189,6 +200,16 @@ func TestArticleRendering(t *testing.T) {
 
 		if doc.Find("h2").Length() == 0 {
 			t.Error("expected h2 element to be rendered, but it wasn't")
+		}
+
+		// Expect the reading time estimate to be present and formatted correctly.
+		readingTime := doc.Find("#article-container p.card-date").First().Text()
+		if readingTime == "" {
+			t.Error("expected reading time element to be rendered, but it wasn't")
+		}
+
+		if !strings.HasSuffix(readingTime, " min read") {
+			t.Errorf("expected reading time to match \"X min read\", got %q", readingTime)
 		}
 	})
 }

--- a/internal/storage/parser.go
+++ b/internal/storage/parser.go
@@ -67,6 +67,19 @@ func RemoveHTMLTags(s string) string {
 	return re.ReplaceAllString(s, "")
 }
 
+// ReadingTime estimates the reading time for HTML content.
+// Returns a human-readable string like "3 min read".
+func ReadingTime(htmlBody string) string {
+	text := RemoveHTMLTags(htmlBody)
+	words := strings.Fields(text)
+
+	const wordsPerMinute = 200
+
+	minutes := max(len(words)/wordsPerMinute, 1)
+
+	return strconv.Itoa(minutes) + " min read"
+}
+
 // SanitizeFilename sanitizes a filename for safe file system use.
 func SanitizeFilename(filename string) string {
 	// Strip any directory components from the filename to prevent directory traversal attacks.

--- a/internal/storage/parser.go
+++ b/internal/storage/parser.go
@@ -60,11 +60,12 @@ func GetTags(v reflect.Value, tags []string) []string {
 	return tags
 }
 
+var htmlTagRegex = regexp.MustCompile(`<[^>]*>`)
+
 // RemoveHTMLTags strips all HTML tags from a string.
 func RemoveHTMLTags(s string) string {
-	re := regexp.MustCompile(`<[^>]*>`)
-
-	return re.ReplaceAllString(s, "")
+	stripped := htmlTagRegex.ReplaceAllString(s, " ")
+	return strings.Join(strings.Fields(stripped), " ")
 }
 
 // ReadingTime estimates the reading time for HTML content.
@@ -75,7 +76,7 @@ func ReadingTime(htmlBody string) string {
 
 	const wordsPerMinute = 200
 
-	minutes := max(len(words)/wordsPerMinute, 1)
+	minutes := max((len(words)+wordsPerMinute-1)/wordsPerMinute, 1)
 
 	return strconv.Itoa(minutes) + " min read"
 }

--- a/internal/storage/parser.go
+++ b/internal/storage/parser.go
@@ -65,6 +65,7 @@ var htmlTagRegex = regexp.MustCompile(`<[^>]*>`)
 // RemoveHTMLTags strips all HTML tags from a string.
 func RemoveHTMLTags(s string) string {
 	stripped := htmlTagRegex.ReplaceAllString(s, " ")
+
 	return strings.Join(strings.Fields(stripped), " ")
 }
 

--- a/internal/storage/parser_test.go
+++ b/internal/storage/parser_test.go
@@ -149,46 +149,29 @@ func TestGetTags(t *testing.T) {
 func TestReadingTime(t *testing.T) {
 	t.Parallel()
 
-	t.Run("short content returns 1 min", func(t *testing.T) {
-		t.Parallel()
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"short content returns 1 min", "<p>Hello world</p>", "1 min read"},
+		{"long content estimates correctly", "<p>" + strings.Repeat("word ", 600) + "</p>", "3 min read"},
+		{"strips HTML before counting", "<h1>Title</h1><p>One <strong>two</strong> three</p>", "1 min read"},
+		{"empty content returns 1 min", "", "1 min read"},
+		{"just over threshold rounds up", "<p>" + strings.Repeat("word ", 201) + "</p>", "2 min read"},
+	}
 
-		result := storage.ReadingTime("<p>Hello world</p>")
-		if result != "1 min read" {
-			t.Errorf("expected %q, got %q", "1 min read", result)
-		}
-	})
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	t.Run("long content estimates correctly", func(t *testing.T) {
-		t.Parallel()
-
-		words := strings.Repeat("word ", 600)
-		html := "<p>" + words + "</p>"
-
-		result := storage.ReadingTime(html)
-		if result != "3 min read" {
-			t.Errorf("expected %q, got %q", "3 min read", result)
-		}
-	})
-
-	t.Run("strips HTML before counting", func(t *testing.T) {
-		t.Parallel()
-
-		html := "<h1>Title</h1><p>One <strong>two</strong> three</p>"
-
-		result := storage.ReadingTime(html)
-		if result != "1 min read" {
-			t.Errorf("expected %q, got %q", "1 min read", result)
-		}
-	})
-
-	t.Run("empty content returns 1 min", func(t *testing.T) {
-		t.Parallel()
-
-		result := storage.ReadingTime("")
-		if result != "1 min read" {
-			t.Errorf("expected %q, got %q", "1 min read", result)
-		}
-	})
+			result := storage.ReadingTime(tc.input)
+			if result != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, result)
+			}
+		})
+	}
 }
 
 func TestHTMLParsing(t *testing.T) {

--- a/internal/storage/parser_test.go
+++ b/internal/storage/parser_test.go
@@ -159,6 +159,7 @@ func TestReadingTime(t *testing.T) {
 		{"strips HTML before counting", "<h1>Title</h1><p>One <strong>two</strong> three</p>", "1 min read"},
 		{"empty content returns 1 min", "", "1 min read"},
 		{"just over threshold rounds up", "<p>" + strings.Repeat("word ", 201) + "</p>", "2 min read"},
+		{"adjacent tags preserve word boundaries", "<h1>Title</h1><p>Body</p>", "1 min read"},
 	}
 
 	for _, tc := range tests {
@@ -187,6 +188,17 @@ func TestHTMLParsing(t *testing.T) {
 			t.Errorf("Expected %s, got %s", expected, result)
 		}
 	})
+	t.Run("adjacent tags preserve word boundaries", func(t *testing.T) {
+		t.Parallel()
+
+		input := `<h1>Title</h1><p>Body</p>`
+		result := storage.RemoveHTMLTags(input)
+
+		if result != "Title Body" {
+			t.Errorf("expected %q, got %q", "Title Body", result)
+		}
+	})
+
 	t.Run("filenames are sanitized and formatted", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/storage/parser_test.go
+++ b/internal/storage/parser_test.go
@@ -162,7 +162,6 @@ func TestReadingTime(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/storage/parser_test.go
+++ b/internal/storage/parser_test.go
@@ -146,6 +146,51 @@ func TestGetTags(t *testing.T) {
 	})
 }
 
+func TestReadingTime(t *testing.T) {
+	t.Parallel()
+
+	t.Run("short content returns 1 min", func(t *testing.T) {
+		t.Parallel()
+
+		result := storage.ReadingTime("<p>Hello world</p>")
+		if result != "1 min read" {
+			t.Errorf("expected %q, got %q", "1 min read", result)
+		}
+	})
+
+	t.Run("long content estimates correctly", func(t *testing.T) {
+		t.Parallel()
+
+		words := strings.Repeat("word ", 600)
+		html := "<p>" + words + "</p>"
+
+		result := storage.ReadingTime(html)
+		if result != "3 min read" {
+			t.Errorf("expected %q, got %q", "3 min read", result)
+		}
+	})
+
+	t.Run("strips HTML before counting", func(t *testing.T) {
+		t.Parallel()
+
+		html := "<h1>Title</h1><p>One <strong>two</strong> three</p>"
+
+		result := storage.ReadingTime(html)
+		if result != "1 min read" {
+			t.Errorf("expected %q, got %q", "1 min read", result)
+		}
+	})
+
+	t.Run("empty content returns 1 min", func(t *testing.T) {
+		t.Parallel()
+
+		result := storage.ReadingTime("")
+		if result != "1 min read" {
+			t.Errorf("expected %q, got %q", "1 min read", result)
+		}
+	})
+}
+
 func TestHTMLParsing(t *testing.T) {
 	t.Parallel()
 	t.Run("remove HTML tags from string", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `ReadingTime()` function to `internal/storage/parser.go` — strips HTML, counts words, estimates minutes at 200 WPM
- Display reading time on article detail pages via `ArticleDisplay` component
- Add 4 test cases covering short/long content, HTML stripping, and empty input

## Test plan
- [x] `make test` — all tests pass
- [x] `make build` — builds cleanly
- [x] Lint passes with 0 issues
- [ ] Verify reading time displays correctly on article detail pages in browser