### PR TITLE
feat: add security headers middleware

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -166,7 +166,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 		web.GetLetterHandler(w, r, *s.Storage, letterID, s.auth)
 	}))
 	// Wrap: recovery is outermost so it catches panics from all inner middleware.
-	return recoveryMiddleware(s.corsMiddleware(s.maxBytesMiddleware(mux)))
+	return recoveryMiddleware(securityHeadersMiddleware(s.corsMiddleware(s.maxBytesMiddleware(mux))))
 }
 
 func recoveryMiddleware(next http.Handler) http.Handler {
@@ -187,6 +187,20 @@ func recoveryMiddleware(next http.Handler) http.Handler {
 func (s *Server) maxBytesMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		r.Body = http.MaxBytesReader(w, r.Body, 10<<20)
+		next.ServeHTTP(w, r)
+	})
+}
+
+func securityHeadersMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		w.Header().Set(
+			"Permissions-Policy",
+			"camera=(), microphone=(), geolocation=()",
+		)
+
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -4,9 +4,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"timterests/internal/server"
+	"timterests/internal/storage"
 )
 
 func TestRoutes(t *testing.T) {
@@ -51,4 +53,50 @@ func TestRoutes(t *testing.T) {
 			t.Errorf("expected response body to be %v; got %v", expected, string(body))
 		}
 	})
+}
+
+func TestSecurityHeaders(t *testing.T) {
+	setupHealthTestDB(t)
+
+	s := &server.Server{
+		Storage: &storage.Storage{
+			UseS3:   false,
+			BaseDir: t.TempDir(),
+		},
+	}
+
+	svr := httptest.NewServer(s.RegisterRoutes())
+	defer svr.Close()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svr.URL+"/health", nil)
+	if err != nil {
+		t.Fatalf("error creating request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("error making request: %v", err)
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	headers := map[string]string{
+		"X-Content-Type-Options": "nosniff",
+		"X-Frame-Options":        "DENY",
+		"Referrer-Policy":        "strict-origin-when-cross-origin",
+	}
+
+	for name, want := range headers {
+		got := resp.Header.Get(name)
+		if got != want {
+			t.Errorf("header %s: got %q, want %q", name, got, want)
+		}
+	}
+
+	pp := resp.Header.Get("Permissions-Policy")
+	if !strings.Contains(pp, "camera=()") {
+		t.Errorf("Permissions-Policy missing camera=(), got %q", pp)
+	}
 }


### PR DESCRIPTION
## Summary
- Add `securityHeadersMiddleware` to the HTTP middleware chain
- Sets `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`, and `Permissions-Policy` restricting camera/microphone/geolocation
- Add test verifying all security headers are present on responses

## Test plan
- [x] `make test` — all tests pass
- [x] `golangci-lint run ./internal/server/` — 0 issues
- [x] Test hits `/health` through full middleware chain and asserts header values