### PR TITLE
fix: use go tool templ to pin generator version to go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,18 +22,15 @@ jobs:
           go-version: "1.26"
           cache: true
 
-      - name: Install Templ
-        run: go install github.com/a-h/templ/cmd/templ@latest
-
       - name: Generate Templ files
-        run: templ generate
+        run: go tool templ generate
 
       - name: Build
         run: go build -v ./...
 
   test:
     name: Test and Coverage
-    runs-on: ubuntu-latest
+    runs-on7 ubuntu-latest
     steps:
       - uses: actions/checkout@v5
 
@@ -43,11 +40,8 @@ jobs:
           go-version: "1.26"
           cache: true
 
-      - name: Install Templ
-        run: go install github.com/a-h/templ/cmd/templ@latest
-
       - name: Generate Templ files
-        run: templ generate
+        run: go tool templ generate
 
       - name: Run tests
         run: go test -v ./...
@@ -74,11 +68,8 @@ jobs:
           go-version: "1.26"
           cache: true
 
-      - name: Install Templ
-        run: go install github.com/a-h/templ/cmd/templ@latest
-
       - name: Generate Templ files
-        run: templ generate
+        run: go tool templ generate
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
   test:
     name: Test and Coverage
-    runs-on7 ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
 

--- a/Makefile
+++ b/Makefile
@@ -2,24 +2,9 @@
 
 # Build the application
 all: build test
-templ-install:
-	@if ! command -v templ > /dev/null; then \
-		read -p "Go's 'templ' is not installed on your machine. Do you want to install it? [Y/n] " choice; \
-		if [ "$$choice" != "n" ] && [ "$$choice" != "N" ]; then \
-			go install github.com/a-h/templ/cmd/templ@latest; \
-			if [ ! -x "$$(command -v templ)" ]; then \
-				echo "templ installation failed. Exiting..."; \
-				exit 1; \
-			fi; \
-		else \
-			echo "You chose not to install templ. Exiting..."; \
-			exit 1; \
-		fi; \
-	fi
-
-build: templ-install
+build:
 	@echo "Building..."
-	@templ generate
+	@go tool templ generate
 
 	@CGO_ENABLED=1 go build -o main cmd/api/main.go
 
@@ -117,4 +102,4 @@ deploy:
 	fi
 
 
-.PHONY: all build run test coverage clean watch templ-install create-user deploy complexity docker-run docker-down
+.PHONY: all build run test coverage clean watch create-user deploy complexity docker-run docker-down


### PR DESCRIPTION
## Summary

- CI was installing `templ@latest` (`v0.3.1020`) which generates code calling `templ.ResolveAttributeValue`
- `go.mod` pins the library at `v0.3.1001`, which doesn't have that symbol
- Result: build fails with `undefined: templ.ResolveAttributeValue` across all branches

## Fix

`go.mod` already has a `tool` directive for templ. Switching CI to use `go tool templ generate` ensures the generator always runs at the version pinned in `go.mod` — eliminates this class of mismatch permanently.

**Changes:** Removed the `go install github.com/a-h/templ/cmd/templ@latest` step from all three jobs and replaced `templ generate` with `go tool templ generate`.

## Test plan

- [ ] CI passes on this PR (validates the fix works)
- [ ] After merge, confirm PRs #172–176 go green on their next CI run