### PR TITLE
test: coverage - components, auth, server, scripts

### DIFF
--- a/cmd/web/admin_documents_test.go
+++ b/cmd/web/admin_documents_test.go
@@ -191,6 +191,77 @@ func TestAdminDocumentsPageHandler(t *testing.T) {
 	})
 }
 
+func TestAdminDocumentsSortByModified(t *testing.T) {
+	a, addAuthCookie := testAuthentication(t)
+	s := testSetup(t, context.Background())
+
+	t.Run("modified ascending returns 200", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(
+			context.Background(), http.MethodGet,
+			"/admin/documents?sort=modified&dir=asc", nil,
+		)
+		rec := httptest.NewRecorder()
+
+		addAuthCookie(req)
+		web.AdminDocumentsPageHandler(rec, req, *s, a)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+	})
+
+	t.Run("modified descending returns 200", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(
+			context.Background(), http.MethodGet,
+			"/admin/documents?sort=modified&dir=desc", nil,
+		)
+		rec := httptest.NewRecorder()
+
+		addAuthCookie(req)
+		web.AdminDocumentsPageHandler(rec, req, *s, a)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+	})
+
+	t.Run("filename ascending is ordered", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(
+			context.Background(), http.MethodGet,
+			"/admin/documents?sort=filename&dir=asc", nil,
+		)
+		rec := httptest.NewRecorder()
+
+		addAuthCookie(req)
+		web.AdminDocumentsPageHandler(rec, req, *s, a)
+
+		doc, err := goquery.NewDocumentFromReader(rec.Body)
+		if err != nil {
+			t.Fatalf("failed to parse response: %v", err)
+		}
+
+		var filenames []string
+
+		doc.Find("table.admin-table tbody tr td:first-child").Each(
+			func(_ int, sel *goquery.Selection) {
+				name := strings.TrimSpace(sel.Text())
+				if name != "" {
+					filenames = append(filenames, name)
+				}
+			},
+		)
+
+		for i := 1; i < len(filenames); i++ {
+			if filenames[i-1] > filenames[i] {
+				t.Errorf(
+					"filenames not sorted ascending: %q > %q",
+					filenames[i-1], filenames[i],
+				)
+			}
+		}
+	})
+}
+
 func TestListAllDocuments(t *testing.T) {
 	s := testSetup(t, context.Background())
 

--- a/cmd/web/admin_documents_test.go
+++ b/cmd/web/admin_documents_test.go
@@ -195,7 +195,7 @@ func TestAdminDocumentsSortByModified(t *testing.T) {
 	a, addAuthCookie := testAuthentication(t)
 	s := testSetup(t, context.Background())
 
-	t.Run("modified ascending returns 200", func(t *testing.T) {
+	t.Run("modified ascending is ordered", func(t *testing.T) {
 		req := httptest.NewRequestWithContext(
 			context.Background(), http.MethodGet,
 			"/admin/documents?sort=modified&dir=asc", nil,
@@ -206,11 +206,35 @@ func TestAdminDocumentsSortByModified(t *testing.T) {
 		web.AdminDocumentsPageHandler(rec, req, *s, a)
 
 		if rec.Code != http.StatusOK {
-			t.Errorf("expected status 200, got %d", rec.Code)
+			t.Fatalf("expected status 200, got %d", rec.Code)
+		}
+
+		doc, err := goquery.NewDocumentFromReader(rec.Body)
+		if err != nil {
+			t.Fatalf("failed to parse response: %v", err)
+		}
+
+		var dates []string
+
+		doc.Find("table.admin-table tbody tr").Each(func(_ int, row *goquery.Selection) {
+			date := strings.TrimSpace(row.Find("td").Eq(2).Text())
+			if date != "" {
+				dates = append(dates, date)
+			}
+		})
+
+		if len(dates) < 2 {
+			t.Fatalf("expected at least 2 dates to verify sort, got %d", len(dates))
+		}
+
+		for i := 1; i < len(dates); i++ {
+			if dates[i-1] > dates[i] {
+				t.Errorf("dates not sorted ascending: %q > %q", dates[i-1], dates[i])
+			}
 		}
 	})
 
-	t.Run("modified descending returns 200", func(t *testing.T) {
+	t.Run("modified descending is ordered", func(t *testing.T) {
 		req := httptest.NewRequestWithContext(
 			context.Background(), http.MethodGet,
 			"/admin/documents?sort=modified&dir=desc", nil,
@@ -221,7 +245,31 @@ func TestAdminDocumentsSortByModified(t *testing.T) {
 		web.AdminDocumentsPageHandler(rec, req, *s, a)
 
 		if rec.Code != http.StatusOK {
-			t.Errorf("expected status 200, got %d", rec.Code)
+			t.Fatalf("expected status 200, got %d", rec.Code)
+		}
+
+		doc, err := goquery.NewDocumentFromReader(rec.Body)
+		if err != nil {
+			t.Fatalf("failed to parse response: %v", err)
+		}
+
+		var dates []string
+
+		doc.Find("table.admin-table tbody tr").Each(func(_ int, row *goquery.Selection) {
+			date := strings.TrimSpace(row.Find("td").Eq(2).Text())
+			if date != "" {
+				dates = append(dates, date)
+			}
+		})
+
+		if len(dates) < 2 {
+			t.Fatalf("expected at least 2 dates to verify sort, got %d", len(dates))
+		}
+
+		for i := 1; i < len(dates); i++ {
+			if dates[i-1] < dates[i] {
+				t.Errorf("dates not sorted descending: %q < %q", dates[i-1], dates[i])
+			}
 		}
 	})
 

--- a/cmd/web/articles_test.go
+++ b/cmd/web/articles_test.go
@@ -209,6 +209,65 @@ func TestGetArticleNotFound(t *testing.T) {
 	})
 }
 
+func TestFormatDateForFilename(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"valid date", "2026-01-15", "01-15-2026"},
+		{"invalid date returns original", "not-a-date", "not-a-date"},
+		{"empty string", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := web.FormatDateForFilename(tc.input)
+			if got != tc.expected {
+				t.Errorf("FormatDateForFilename(%q) = %q, want %q", tc.input, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestArticlesGridDesign(t *testing.T) {
+	s := testSetup(t, context.Background())
+
+	t.Run("render articles with grid design", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequestWithContext(
+			context.Background(), http.MethodGet, "/articles?design=grid", nil,
+		)
+		rec := httptest.NewRecorder()
+
+		web.ArticlesPageHandler(rec, req, *s, "all", "grid")
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+	})
+
+	t.Run("render articles with links design", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequestWithContext(
+			context.Background(), http.MethodGet, "/articles?design=links", nil,
+		)
+		rec := httptest.NewRecorder()
+
+		web.ArticlesPageHandler(rec, req, *s, "all", "links")
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+	})
+}
+
 func TestArticleCardConversion(t *testing.T) {
 	ctx := context.Background()
 	s := testSetup(t, ctx)

--- a/cmd/web/articles_test.go
+++ b/cmd/web/articles_test.go
@@ -248,7 +248,16 @@ func TestArticlesGridDesign(t *testing.T) {
 		web.ArticlesPageHandler(rec, req, *s, "all", "grid")
 
 		if rec.Code != http.StatusOK {
-			t.Errorf("expected status 200, got %d", rec.Code)
+			t.Fatalf("expected status 200, got %d", rec.Code)
+		}
+
+		doc, err := goquery.NewDocumentFromReader(rec.Body)
+		if err != nil {
+			t.Fatalf("failed to parse response: %v", err)
+		}
+
+		if doc.Find("li.grid-list-element").Length() == 0 {
+			t.Error("expected grid-list-element for grid design, but found none")
 		}
 	})
 
@@ -263,7 +272,16 @@ func TestArticlesGridDesign(t *testing.T) {
 		web.ArticlesPageHandler(rec, req, *s, "all", "links")
 
 		if rec.Code != http.StatusOK {
-			t.Errorf("expected status 200, got %d", rec.Code)
+			t.Fatalf("expected status 200, got %d", rec.Code)
+		}
+
+		doc, err := goquery.NewDocumentFromReader(rec.Body)
+		if err != nil {
+			t.Fatalf("failed to parse response: %v", err)
+		}
+
+		if doc.Find("div.link-item").Length() == 0 {
+			t.Error("expected link-item elements for links design, but found none")
 		}
 	})
 }

--- a/cmd/web/components/card_test.go
+++ b/cmd/web/components/card_test.go
@@ -1,0 +1,202 @@
+package components_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"timterests/cmd/web/components"
+)
+
+func render(t *testing.T, c interface{ Render(ctx context.Context, w io.Writer) error }) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	err := c.Render(context.Background(), &buf)
+	if err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+
+	return buf.String()
+}
+
+func TestLargeCard(t *testing.T) {
+	t.Parallel()
+
+	t.Run("renders all fields", func(t *testing.T) {
+		t.Parallel()
+
+		c := components.Card{
+			Title:     "Test Title",
+			Subtitle:  "Test Sub",
+			Date:      "2026-01-15",
+			Preview:   "Some preview text.",
+			ImagePath: "/images/test.png",
+			Get:       "/article?id=1",
+			Tags:      []string{"go", "testing"},
+			Index:     2,
+		}
+
+		html := render(t, c.LargeCard())
+
+		for _, want := range []string{
+			"Test Title",
+			"Test Sub",
+			"2026-01-15",
+			"Some preview text.",
+			"/images/test.png",
+			"/article?id=1",
+			"go",
+			"testing",
+			"card-container",
+			"animation-delay: 0.2s",
+		} {
+			if !strings.Contains(html, want) {
+				t.Errorf("LargeCard missing %q", want)
+			}
+		}
+	})
+
+	t.Run("omits image when ImagePath is empty", func(t *testing.T) {
+		t.Parallel()
+
+		c := components.Card{Title: "No Image", Get: "/x"}
+		html := render(t, c.LargeCard())
+
+		if strings.Contains(html, "card-image") {
+			t.Error("expected no card-image when ImagePath is empty")
+		}
+	})
+
+	t.Run("omits date when empty", func(t *testing.T) {
+		t.Parallel()
+
+		c := components.Card{Title: "No Date", Get: "/x"}
+		html := render(t, c.LargeCard())
+
+		if strings.Contains(html, "card-date") {
+			t.Error("expected no card-date when Date is empty")
+		}
+	})
+}
+
+func TestMiniCard(t *testing.T) {
+	t.Parallel()
+
+	t.Run("renders title and tags", func(t *testing.T) {
+		t.Parallel()
+
+		c := components.Card{
+			Title: "Mini Title",
+			Get:   "/mini",
+			Tags:  []string{"rust"},
+			Index: 0,
+		}
+
+		html := render(t, c.MiniCard())
+
+		for _, want := range []string{
+			"Mini Title",
+			"mini-card-container",
+			"rust",
+			"animation-delay: 0.0s",
+		} {
+			if !strings.Contains(html, want) {
+				t.Errorf("MiniCard missing %q", want)
+			}
+		}
+	})
+
+	t.Run("renders image when present", func(t *testing.T) {
+		t.Parallel()
+
+		c := components.Card{Title: "With Img", Get: "/x", ImagePath: "/img/cover.jpg"}
+		html := render(t, c.MiniCard())
+
+		if !strings.Contains(html, "card-image") {
+			t.Error("expected card-image in MiniCard with ImagePath")
+		}
+	})
+}
+
+func TestLinkCard(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with date shows date dash title", func(t *testing.T) {
+		t.Parallel()
+
+		c := components.Card{Title: "Link Title", Date: "2026-03-01", Get: "/link"}
+		html := render(t, c.LinkCard())
+
+		if !strings.Contains(html, "2026-03-01") {
+			t.Error("expected date in LinkCard")
+		}
+
+		if !strings.Contains(html, "Link Title") {
+			t.Error("expected title in LinkCard")
+		}
+
+		if !strings.Contains(html, "link-item") {
+			t.Error("expected link-item class")
+		}
+	})
+
+	t.Run("without date shows only title", func(t *testing.T) {
+		t.Parallel()
+
+		c := components.Card{Title: "No Date Link", Get: "/link2"}
+		html := render(t, c.LinkCard())
+
+		if !strings.Contains(html, "No Date Link") {
+			t.Error("expected title")
+		}
+
+		if strings.Contains(html, " - ") {
+			t.Error("expected no dash separator without date")
+		}
+	})
+}
+
+func TestCardTitleContainer(t *testing.T) {
+	t.Parallel()
+
+	html := render(t, components.CardTitleContainer("Main Title", "Sub Title"))
+
+	for _, want := range []string{
+		"card-title-container",
+		"Main Title",
+		"Sub Title",
+		"card-title",
+		"card-subtitle",
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("CardTitleContainer missing %q", want)
+		}
+	}
+}
+
+func TestAnimationDelay(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		index int
+		want  string
+	}{
+		{0, "0.0s"},
+		{1, "0.1s"},
+		{5, "0.5s"},
+		{10, "1.0s"},
+	}
+
+	for _, tc := range tests {
+		c := components.Card{Title: "T", Get: "/x", Index: tc.index}
+		html := render(t, c.LargeCard())
+
+		if !strings.Contains(html, tc.want) {
+			t.Errorf("Index %d: expected delay %q in HTML", tc.index, tc.want)
+		}
+	}
+}

--- a/cmd/web/components/download_test.go
+++ b/cmd/web/components/download_test.go
@@ -1,0 +1,63 @@
+package components_test
+
+import (
+	"strings"
+	"testing"
+
+	"timterests/cmd/web/components"
+)
+
+func TestDownloadDocumentButton(t *testing.T) {
+	t.Parallel()
+
+	t.Run("renders button for admin", func(t *testing.T) {
+		t.Parallel()
+
+		html := render(t, components.DownloadDocumentButton("articles/doc.yaml", true))
+
+		for _, want := range []string{
+			`action="/download"`,
+			`name="key"`,
+			`value="articles/doc.yaml"`,
+			"Download",
+		} {
+			if !strings.Contains(html, want) {
+				t.Errorf("DownloadDocumentButton missing %q", want)
+			}
+		}
+	})
+
+	t.Run("renders nothing for non-admin", func(t *testing.T) {
+		t.Parallel()
+
+		html := render(t, components.DownloadDocumentButton("articles/doc.yaml", false))
+
+		if strings.Contains(html, "Download") {
+			t.Error("expected no content for non-admin")
+		}
+	})
+}
+
+func TestDownloadNewDocumentButton(t *testing.T) {
+	t.Parallel()
+
+	t.Run("renders button for admin", func(t *testing.T) {
+		t.Parallel()
+
+		html := render(t, components.DownloadNewDocumentButton(true))
+
+		if !strings.Contains(html, `formaction="/download/new"`) {
+			t.Error("expected formaction for download/new")
+		}
+	})
+
+	t.Run("renders nothing for non-admin", func(t *testing.T) {
+		t.Parallel()
+
+		html := render(t, components.DownloadNewDocumentButton(false))
+
+		if strings.Contains(html, "Download") {
+			t.Error("expected no content for non-admin")
+		}
+	})
+}

--- a/cmd/web/components/filter_test.go
+++ b/cmd/web/components/filter_test.go
@@ -1,0 +1,90 @@
+package components_test
+
+import (
+	"strings"
+	"testing"
+
+	"timterests/cmd/web/components"
+)
+
+func TestFilterTags(t *testing.T) {
+	t.Parallel()
+
+	t.Run("renders all tag options plus All", func(t *testing.T) {
+		t.Parallel()
+
+		html := render(t, components.FilterTags("/articles", []string{"go", "rust", "python"}))
+
+		for _, want := range []string{
+			"filter-select",
+			`value="all"`,
+			"All",
+			`value="go"`,
+			`value="rust"`,
+			`value="python"`,
+			`hx-get="/articles"`,
+			`name="tag"`,
+		} {
+			if !strings.Contains(html, want) {
+				t.Errorf("FilterTags missing %q", want)
+			}
+		}
+	})
+
+	t.Run("empty tags renders only All option", func(t *testing.T) {
+		t.Parallel()
+
+		html := render(t, components.FilterTags("/x", nil))
+
+		if !strings.Contains(html, "All") {
+			t.Error("expected All option")
+		}
+
+		if count := strings.Count(html, "<option"); count != 1 {
+			t.Errorf("expected 1 option element, got %d", count)
+		}
+	})
+}
+
+func TestFilterDesign(t *testing.T) {
+	t.Parallel()
+
+	t.Run("list design is active by default", func(t *testing.T) {
+		t.Parallel()
+
+		html := render(t, components.FilterDesign("/articles", "list"))
+
+		if !strings.Contains(html, "view-options") {
+			t.Error("expected view-options container")
+		}
+
+		buttons := strings.Count(html, "view-btn")
+		if buttons < 3 {
+			t.Errorf("expected at least 3 view-btn references, got %d", buttons)
+		}
+	})
+
+	t.Run("empty design defaults to list active", func(t *testing.T) {
+		t.Parallel()
+
+		html := render(t, components.FilterDesign("/articles", ""))
+
+		if !strings.Contains(html, `"design": "list"`) {
+			t.Error("expected list design hx-vals")
+		}
+
+		if !strings.Contains(html, `"design": "grid"`) {
+			t.Error("expected grid design hx-vals")
+		}
+	})
+
+	t.Run("grid design renders grid button active", func(t *testing.T) {
+		t.Parallel()
+
+		html := render(t, components.FilterDesign("/projects", "grid"))
+
+		if !strings.Contains(html, `hx-get="/projects"`) {
+			t.Error("expected hx-get for projects")
+		}
+	})
+}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"timterests/internal/auth"
+	"timterests/internal/storage"
 
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -178,13 +179,7 @@ func setupAuthDB(t *testing.T) {
 	}
 	defer db.Close()
 
-	_, err = db.ExecContext(context.Background(), `CREATE TABLE IF NOT EXISTS users (
-		id INTEGER PRIMARY KEY AUTOINCREMENT,
-		first_name TEXT NOT NULL,
-		last_name TEXT NOT NULL,
-		email TEXT UNIQUE NOT NULL,
-		password TEXT NOT NULL
-	)`)
+	err = storage.CreateUserTable(context.Background(), db)
 	if err != nil {
 		t.Fatalf("failed to create users table: %v", err)
 	}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -2,11 +2,17 @@ package auth_test
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"timterests/internal/auth"
+
+	_ "github.com/mattn/go-sqlite3"
 )
 
 func newRequest() *http.Request {
@@ -150,6 +156,159 @@ func TestSetSessionValue(t *testing.T) {
 
 		if !a.IsAuthenticated(r2) {
 			t.Error("expected authenticated after setting email")
+		}
+	})
+}
+
+func setupAuthDB(t *testing.T) {
+	t.Helper()
+
+	dbDir := filepath.Join(t.TempDir(), "database")
+
+	err := os.MkdirAll(dbDir, 0750)
+	if err != nil {
+		t.Fatalf("failed to create database dir: %v", err)
+	}
+
+	dbPath := filepath.Join(dbDir, "timterests.db")
+
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	defer db.Close()
+
+	_, err = db.ExecContext(context.Background(), `CREATE TABLE IF NOT EXISTS users (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		first_name TEXT NOT NULL,
+		last_name TEXT NOT NULL,
+		email TEXT UNIQUE NOT NULL,
+		password TEXT NOT NULL
+	)`)
+	if err != nil {
+		t.Fatalf("failed to create users table: %v", err)
+	}
+
+	t.Chdir(filepath.Dir(dbDir))
+}
+
+func TestCreateUser(t *testing.T) {
+	t.Run("creates user successfully", func(t *testing.T) {
+		setupAuthDB(t)
+
+		a := auth.NewAuth("test-session")
+		ctx := context.Background()
+
+		err := a.CreateUser(ctx, "John", "Doe", "john@example.com", "Pass123!")
+		if err != nil {
+			t.Fatalf("CreateUser failed: %v", err)
+		}
+	})
+
+	t.Run("rejects duplicate email", func(t *testing.T) {
+		setupAuthDB(t)
+
+		a := auth.NewAuth("test-session")
+		ctx := context.Background()
+
+		err := a.CreateUser(ctx, "A", "B", "dup@test.com", "Pass123!")
+		if err != nil {
+			t.Fatalf("first CreateUser failed: %v", err)
+		}
+
+		err = a.CreateUser(ctx, "C", "D", "dup@test.com", "Pass456!")
+		if err == nil {
+			t.Error("expected error for duplicate email")
+		}
+	})
+
+	t.Run("rejects empty password", func(t *testing.T) {
+		setupAuthDB(t)
+
+		a := auth.NewAuth("test-session")
+
+		err := a.CreateUser(context.Background(), "X", "Y", "x@test.com", "")
+		if err == nil {
+			t.Error("expected error for empty password")
+		}
+	})
+}
+
+func TestAuthenticate(t *testing.T) {
+	t.Run("succeeds with correct credentials", func(t *testing.T) {
+		setupAuthDB(t)
+
+		a := auth.NewAuth("test-session")
+		ctx := context.Background()
+
+		err := a.CreateUser(ctx, "Auth", "User", "auth@test.com", "Correct123!")
+		if err != nil {
+			t.Fatalf("CreateUser failed: %v", err)
+		}
+
+		w := httptest.NewRecorder()
+		r := newRequest()
+
+		ok, err := a.Authenticate(ctx, w, r, "auth@test.com", "Correct123!")
+		if err != nil {
+			t.Fatalf("Authenticate failed: %v", err)
+		}
+
+		if !ok {
+			t.Error("expected authentication to succeed")
+		}
+
+		r2 := newRequest()
+		for _, c := range w.Result().Cookies() {
+			r2.AddCookie(c)
+		}
+
+		if !a.IsAuthenticated(r2) {
+			t.Error("expected session to be set after authentication")
+		}
+	})
+
+	t.Run("fails with wrong password", func(t *testing.T) {
+		setupAuthDB(t)
+
+		a := auth.NewAuth("test-session")
+		ctx := context.Background()
+
+		err := a.CreateUser(ctx, "Auth", "User", "wrong@test.com", "Correct123!")
+		if err != nil {
+			t.Fatalf("CreateUser failed: %v", err)
+		}
+
+		w := httptest.NewRecorder()
+		r := newRequest()
+
+		ok, err := a.Authenticate(ctx, w, r, "wrong@test.com", "WrongPass!")
+		if ok {
+			t.Error("expected authentication to fail")
+		}
+
+		if !errors.Is(err, auth.ErrInvalidCredentials) {
+			t.Errorf("expected ErrInvalidCredentials, got %v", err)
+		}
+	})
+
+	t.Run("fails with nonexistent email", func(t *testing.T) {
+		setupAuthDB(t)
+
+		a := auth.NewAuth("test-session")
+
+		w := httptest.NewRecorder()
+		r := newRequest()
+
+		ok, err := a.Authenticate(
+			context.Background(), w, r, "nobody@test.com", "Pass123!",
+		)
+		if ok {
+			t.Error("expected authentication to fail")
+		}
+
+		if !errors.Is(err, auth.ErrInvalidCredentials) {
+			t.Errorf("expected ErrInvalidCredentials, got %v", err)
 		}
 	})
 }

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -1,0 +1,7 @@
+package server
+
+import "net/http"
+
+func (s *Server) MaxBytesMiddleware(next http.Handler) http.Handler {
+	return s.maxBytesMiddleware(next)
+}

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -1,4 +1,4 @@
-package server
+package server_test
 
 import (
 	"io"
@@ -6,27 +6,12 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"timterests/internal/server"
 )
 
-func TestRecoveryMiddlewarePanic(t *testing.T) {
-	panicking := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		panic("test panic")
-	})
-
-	handler := recoveryMiddleware(panicking)
-
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
-
-	handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusInternalServerError {
-		t.Errorf("expected 500 after panic, got %d", rec.Code)
-	}
-}
-
 func TestMaxBytesMiddlewareRejectsOversizedBody(t *testing.T) {
-	s := &Server{}
+	s := &server.Server{}
 
 	drainBody := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := io.ReadAll(r.Body)
@@ -39,7 +24,7 @@ func TestMaxBytesMiddlewareRejectsOversizedBody(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := s.maxBytesMiddleware(drainBody)
+	handler := s.MaxBytesMiddleware(drainBody)
 
 	oversized := strings.NewReader(strings.Repeat("x", 11*1024*1024))
 

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRecoveryMiddlewarePanic(t *testing.T) {
+	panicking := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("test panic")
+	})
+
+	handler := recoveryMiddleware(panicking)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500 after panic, got %d", rec.Code)
+	}
+}
+
+func TestMaxBytesMiddlewareRejectsOversizedBody(t *testing.T) {
+	s := &Server{}
+
+	drainBody := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
+
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := s.maxBytesMiddleware(drainBody)
+
+	oversized := strings.NewReader(strings.Repeat("x", 11*1024*1024))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", oversized)
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusOK {
+		t.Error("expected rejection for oversized body, but got 200")
+	}
+}

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -260,6 +260,7 @@ func TestRegisterRoutesEndpoints(t *testing.T) {
 		"/sitemap.xml",
 		"/about",
 		"/writer",
+		"/writer?type-id=invalid",
 		"/admin",
 		"/admin/documents",
 		"/admin/users",

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -9,6 +9,8 @@ import (
 
 	"timterests/internal/server"
 	"timterests/internal/storage"
+
+	_ "github.com/mattn/go-sqlite3"
 )
 
 func TestRoutes(t *testing.T) {
@@ -98,5 +100,139 @@ func TestSecurityHeaders(t *testing.T) {
 	pp := resp.Header.Get("Permissions-Policy")
 	if !strings.Contains(pp, "camera=()") {
 		t.Errorf("Permissions-Policy missing camera=(), got %q", pp)
+	}
+}
+
+func TestRecoveryMiddleware(t *testing.T) {
+	setupHealthTestDB(t)
+
+	s := &server.Server{
+		Storage: &storage.Storage{
+			UseS3:   false,
+			BaseDir: t.TempDir(),
+		},
+	}
+
+	handler := s.RegisterRoutes()
+
+	svr := httptest.NewServer(handler)
+	defer svr.Close()
+
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodGet, svr.URL+"/health", nil,
+	)
+	if err != nil {
+		t.Fatalf("error creating request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("expected 200 or 503, got %d", resp.StatusCode)
+	}
+}
+
+func TestCORSPreflight(t *testing.T) {
+	setupHealthTestDB(t)
+
+	s := &server.Server{
+		Storage: &storage.Storage{
+			UseS3:   false,
+			BaseDir: t.TempDir(),
+		},
+	}
+
+	svr := httptest.NewServer(s.RegisterRoutes())
+	defer svr.Close()
+
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodOptions, svr.URL+"/health", nil,
+	)
+	if err != nil {
+		t.Fatalf("error creating request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("expected 204 for OPTIONS preflight, got %d", resp.StatusCode)
+	}
+
+	corsHeaders := map[string]string{
+		"Access-Control-Allow-Origin":  "*",
+		"Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS, PATCH",
+	}
+
+	for name, want := range corsHeaders {
+		got := resp.Header.Get(name)
+		if got != want {
+			t.Errorf("header %s: got %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestMaxBytesMiddleware(t *testing.T) {
+	setupHealthTestDB(t)
+
+	s := &server.Server{
+		Storage: &storage.Storage{
+			UseS3:   false,
+			BaseDir: t.TempDir(),
+		},
+	}
+
+	svr := httptest.NewServer(s.RegisterRoutes())
+	defer svr.Close()
+
+	body := strings.NewReader(strings.Repeat("x", 1024))
+
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodPost, svr.URL+"/health", body,
+	)
+	if err != nil {
+		t.Fatalf("error creating request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 500 {
+		t.Errorf("expected non-500 for small body, got %d", resp.StatusCode)
+	}
+}
+
+func TestHelloWorldContentType(t *testing.T) {
+	t.Parallel()
+
+	s := &server.Server{}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(
+		t.Context(), http.MethodGet, "/hello", nil,
+	)
+
+	s.HelloWorldHandler(rec, req)
+
+	ct := rec.Header().Get("Content-Type")
+	if !strings.Contains(ct, "application/json") {
+		t.Errorf("expected JSON content type, got %q", ct)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "Hello World") {
+		t.Errorf("expected Hello World in body, got %q", body)
 	}
 }

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -236,3 +236,105 @@ func TestHelloWorldContentType(t *testing.T) {
 		t.Errorf("expected Hello World in body, got %q", body)
 	}
 }
+
+func TestRegisterRoutesEndpoints(t *testing.T) {
+	s := &server.Server{
+		Storage: &storage.Storage{
+			UseS3:   false,
+			BaseDir: t.TempDir(),
+		},
+	}
+
+	svr := httptest.NewServer(s.RegisterRoutes())
+	defer svr.Close()
+
+	endpoints := []string{
+		"/",
+		"/home",
+		"/web",
+		"/web/home",
+		"/articles",
+		"/projects",
+		"/reading-list",
+		"/login",
+		"/sitemap.xml",
+		"/about",
+		"/writer",
+		"/admin",
+		"/admin/documents",
+		"/admin/users",
+		"/admin/users/create",
+		"/write",
+		"/write/suggest",
+		"/download",
+		"/download/new",
+		"/article",
+		"/project",
+		"/book",
+		"/letter",
+		"/letters",
+	}
+
+	for _, path := range endpoints {
+		t.Run(path, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svr.URL+path, nil)
+			if err != nil {
+				t.Fatalf("error creating request: %v", err)
+			}
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("error making request to %s: %v", path, err)
+			}
+
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode == 0 {
+				t.Errorf("expected non-zero status code for %s", path)
+			}
+		})
+	}
+}
+
+func TestRecoveryMiddlewarePanic(t *testing.T) {
+	s := &server.Server{
+		Storage: &storage.Storage{
+			UseS3:   false,
+			BaseDir: t.TempDir(),
+		},
+		// auth is nil — /letters calls a.IsAuthenticated → nil deref → panic
+	}
+
+	svr := httptest.NewServer(s.RegisterRoutes())
+	defer svr.Close()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svr.URL+"/letters", nil)
+	if err != nil {
+		t.Fatalf("error creating request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("error making request: %v", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected 500 from panic recovery, got %d", resp.StatusCode)
+	}
+}
+
+func TestNewServer(t *testing.T) {
+	t.Setenv("PORT", "18080")
+	t.Setenv("SESSION_NAME", "test-session")
+
+	svr := server.NewServer()
+	if svr == nil {
+		t.Fatal("expected non-nil server")
+	}
+
+	if svr.Addr != ":18080" {
+		t.Errorf("expected addr :18080, got %s", svr.Addr)
+	}
+}

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -103,40 +103,6 @@ func TestSecurityHeaders(t *testing.T) {
 	}
 }
 
-func TestRecoveryMiddleware(t *testing.T) {
-	setupHealthTestDB(t)
-
-	s := &server.Server{
-		Storage: &storage.Storage{
-			UseS3:   false,
-			BaseDir: t.TempDir(),
-		},
-	}
-
-	handler := s.RegisterRoutes()
-
-	svr := httptest.NewServer(handler)
-	defer svr.Close()
-
-	req, err := http.NewRequestWithContext(
-		t.Context(), http.MethodGet, svr.URL+"/health", nil,
-	)
-	if err != nil {
-		t.Fatalf("error creating request: %v", err)
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("request failed: %v", err)
-	}
-
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusServiceUnavailable {
-		t.Errorf("expected 200 or 503, got %d", resp.StatusCode)
-	}
-}
-
 func TestCORSPreflight(t *testing.T) {
 	setupHealthTestDB(t)
 
@@ -178,40 +144,6 @@ func TestCORSPreflight(t *testing.T) {
 		if got != want {
 			t.Errorf("header %s: got %q, want %q", name, got, want)
 		}
-	}
-}
-
-func TestMaxBytesMiddleware(t *testing.T) {
-	setupHealthTestDB(t)
-
-	s := &server.Server{
-		Storage: &storage.Storage{
-			UseS3:   false,
-			BaseDir: t.TempDir(),
-		},
-	}
-
-	svr := httptest.NewServer(s.RegisterRoutes())
-	defer svr.Close()
-
-	body := strings.NewReader(strings.Repeat("x", 1024))
-
-	req, err := http.NewRequestWithContext(
-		t.Context(), http.MethodPost, svr.URL+"/health", body,
-	)
-	if err != nil {
-		t.Fatalf("error creating request: %v", err)
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("request failed: %v", err)
-	}
-
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode >= 500 {
-		t.Errorf("expected non-500 for small body, got %d", resp.StatusCode)
 	}
 }
 

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -535,6 +535,322 @@ func TestCreateUserTable(t *testing.T) {
 	})
 }
 
+func TestLocalPath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid relative path", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := storage.LocalPath("/base", "subdir/file.yaml")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if result != "/base/subdir/file.yaml" {
+			t.Errorf("expected /base/subdir/file.yaml, got %s", result)
+		}
+	})
+
+	t.Run("path traversal is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := storage.LocalPath("/base", "../etc/passwd")
+		if err == nil {
+			t.Error("expected error for path traversal, got nil")
+		}
+	})
+
+	t.Run("absolute filename is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := storage.LocalPath("/base", "/absolute/path")
+		if err == nil {
+			t.Error("expected error for absolute filename, got nil")
+		}
+	})
+}
+
+func TestListObjects(t *testing.T) {
+	t.Parallel()
+
+	t.Run("lists files from existing directory", func(t *testing.T) {
+		t.Parallel()
+
+		baseDir := t.TempDir()
+		dir := filepath.Join(baseDir, "articles")
+
+		err := os.MkdirAll(dir, 0750)
+		if err != nil {
+			t.Fatalf("failed to create articles dir: %v", err)
+		}
+
+		err = os.WriteFile(filepath.Join(dir, "one.yaml"), []byte("title: One"), 0600)
+		if err != nil {
+			t.Fatalf("failed to write file: %v", err)
+		}
+
+		err = os.WriteFile(filepath.Join(dir, "two.yaml"), []byte("title: Two"), 0600)
+		if err != nil {
+			t.Fatalf("failed to write file: %v", err)
+		}
+
+		s := &storage.Storage{UseS3: false, BaseDir: baseDir}
+
+		objects, err := s.ListObjects(context.Background(), "articles")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if len(objects) != 2 {
+			t.Errorf("expected 2 objects, got %d", len(objects))
+		}
+	})
+
+	t.Run("creates directory and returns empty list", func(t *testing.T) {
+		t.Parallel()
+
+		s := &storage.Storage{UseS3: false, BaseDir: t.TempDir()}
+
+		objects, err := s.ListObjects(context.Background(), "newdir")
+		if err != nil {
+			t.Fatalf("expected no error for new dir, got %v", err)
+		}
+
+		if len(objects) != 0 {
+			t.Errorf("expected 0 objects, got %d", len(objects))
+		}
+	})
+
+	t.Run("ignores subdirectories", func(t *testing.T) {
+		t.Parallel()
+
+		baseDir := t.TempDir()
+		dir := filepath.Join(baseDir, "articles")
+
+		err := os.MkdirAll(filepath.Join(dir, "subdir"), 0750)
+		if err != nil {
+			t.Fatalf("failed to create subdirs: %v", err)
+		}
+
+		err = os.WriteFile(filepath.Join(dir, "file.yaml"), []byte("title: File"), 0600)
+		if err != nil {
+			t.Fatalf("failed to write file: %v", err)
+		}
+
+		s := &storage.Storage{UseS3: false, BaseDir: baseDir}
+
+		objects, err := s.ListObjects(context.Background(), "articles")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if len(objects) != 1 {
+			t.Errorf("expected 1 object (subdir ignored), got %d", len(objects))
+		}
+	})
+}
+
+func TestGetFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("opens existing local file", func(t *testing.T) {
+		t.Parallel()
+
+		baseDir := t.TempDir()
+		dir := filepath.Join(baseDir, "articles")
+
+		err := os.MkdirAll(dir, 0750)
+		if err != nil {
+			t.Fatalf("failed to create dir: %v", err)
+		}
+
+		err = os.WriteFile(filepath.Join(dir, "test.yaml"), []byte("title: Test"), 0600)
+		if err != nil {
+			t.Fatalf("failed to write file: %v", err)
+		}
+
+		s := &storage.Storage{UseS3: false, BaseDir: baseDir}
+
+		file, err := s.GetFile(context.Background(), "articles/test.yaml")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		defer file.Close()
+	})
+
+	t.Run("returns error for nonexistent file", func(t *testing.T) {
+		t.Parallel()
+
+		s := &storage.Storage{UseS3: false, BaseDir: t.TempDir()}
+
+		_, err := s.GetFile(context.Background(), "articles/missing.yaml")
+		if err == nil {
+			t.Error("expected error for missing file, got nil")
+		}
+	})
+}
+
+func TestGetPreparedFile(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	dir := filepath.Join(baseDir, "articles")
+
+	err := os.MkdirAll(dir, 0750)
+	if err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+
+	err = os.WriteFile(filepath.Join(dir, "test.yaml"), []byte("title: Prepared Article\nsubtitle: Sub"), 0600)
+	if err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	s := &storage.Storage{UseS3: false, BaseDir: baseDir}
+
+	var doc model.Document
+
+	err = s.GetPreparedFile(context.Background(), "articles/test.yaml", &doc)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if doc.Title != "Prepared Article" {
+		t.Errorf("expected title 'Prepared Article', got %q", doc.Title)
+	}
+}
+
+func TestGetRawFile(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	dir := filepath.Join(baseDir, "articles")
+
+	err := os.MkdirAll(dir, 0750)
+	if err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+
+	err = os.WriteFile(filepath.Join(dir, "raw.yaml"), []byte("title: Raw Article"), 0600)
+	if err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	s := &storage.Storage{UseS3: false, BaseDir: baseDir}
+
+	var doc model.Document
+
+	err = s.GetRawFile(context.Background(), "articles/raw.yaml", &doc)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if doc.Title != "Raw Article" {
+		t.Errorf("expected title 'Raw Article', got %q", doc.Title)
+	}
+}
+
+func TestGetImage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("local mode returns web path", func(t *testing.T) {
+		t.Parallel()
+
+		s := &storage.Storage{UseS3: false, BaseDir: t.TempDir()}
+
+		result, err := s.GetImage(context.Background(), "images/photo.jpg")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		expected := "/storage/images/photo.jpg"
+		if result != expected {
+			t.Errorf("expected %q, got %q", expected, result)
+		}
+	})
+
+	t.Run("returns error for path traversal", func(t *testing.T) {
+		t.Parallel()
+
+		s := &storage.Storage{UseS3: false, BaseDir: t.TempDir()}
+
+		_, err := s.GetImage(context.Background(), "../etc/passwd")
+		if err == nil {
+			t.Error("expected error for path traversal, got nil")
+		}
+	})
+}
+
+func TestGetDocumentBodyRaw(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	dir := filepath.Join(baseDir, "articles")
+
+	err := os.MkdirAll(dir, 0750)
+	if err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+
+	mdContent := "# Test Article\n\nThis is the body."
+
+	err = os.WriteFile(filepath.Join(dir, "test.md"), []byte(mdContent), 0600)
+	if err != nil {
+		t.Fatalf("failed to write md file: %v", err)
+	}
+
+	s := &storage.Storage{UseS3: false, BaseDir: baseDir}
+
+	raw, err := s.GetDocumentBodyRaw(context.Background(), "articles/test.yaml")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if raw != mdContent {
+		t.Errorf("expected %q, got %q", mdContent, raw)
+	}
+}
+
+func TestGetDocumentBody(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	dir := filepath.Join(baseDir, "articles")
+
+	err := os.MkdirAll(dir, 0750)
+	if err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+
+	err = os.WriteFile(filepath.Join(dir, "test.md"), []byte("# Title\n\nBody text."), 0600)
+	if err != nil {
+		t.Fatalf("failed to write md file: %v", err)
+	}
+
+	s := &storage.Storage{UseS3: false, BaseDir: baseDir}
+
+	html, err := s.GetDocumentBody(context.Background(), "articles/test.yaml")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !strings.Contains(html, "<h1") {
+		t.Errorf("expected HTML with h1 tag, got %q", html)
+	}
+}
+
+func TestDownloadS3FileLocalMode(t *testing.T) {
+	t.Parallel()
+
+	s := &storage.Storage{UseS3: false, BaseDir: t.TempDir()}
+
+	err := s.DownloadS3File(context.Background(), "articles/test.yaml")
+	if err != nil {
+		t.Errorf("expected no error in local mode, got %v", err)
+	}
+}
+
 func getYAMLDocument() *fstest.MapFile {
 	return &fstest.MapFile{
 		Data: []byte(

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -441,6 +441,100 @@ func setupHealthDB(t *testing.T) {
 	t.Chdir(filepath.Dir(dbDir))
 }
 
+func TestInitDB(t *testing.T) {
+	t.Run("creates users table when missing", func(t *testing.T) {
+		dbDir := filepath.Join(t.TempDir(), "database")
+
+		err := os.MkdirAll(dbDir, 0750)
+		if err != nil {
+			t.Fatalf("failed to create database dir: %v", err)
+		}
+
+		t.Chdir(filepath.Dir(dbDir))
+
+		err = storage.InitDB(context.Background())
+		if err != nil {
+			t.Fatalf("InitDB failed: %v", err)
+		}
+
+		db, err := sql.Open("sqlite3", filepath.Join(dbDir, "timterests.db"))
+		if err != nil {
+			t.Fatalf("failed to open db: %v", err)
+		}
+		defer db.Close()
+
+		var count int
+
+		err = db.QueryRowContext(
+			context.Background(),
+			"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='users'",
+		).Scan(&count)
+		if err != nil {
+			t.Fatalf("failed to query sqlite_master: %v", err)
+		}
+
+		if count != 1 {
+			t.Errorf("expected users table to exist, got count %d", count)
+		}
+	})
+
+	t.Run("is idempotent when table already exists", func(t *testing.T) {
+		dbDir := filepath.Join(t.TempDir(), "database")
+
+		err := os.MkdirAll(dbDir, 0750)
+		if err != nil {
+			t.Fatalf("failed to create database dir: %v", err)
+		}
+
+		t.Chdir(filepath.Dir(dbDir))
+
+		err = storage.InitDB(context.Background())
+		if err != nil {
+			t.Fatalf("first InitDB failed: %v", err)
+		}
+
+		err = storage.InitDB(context.Background())
+		if err != nil {
+			t.Fatalf("second InitDB failed: %v", err)
+		}
+	})
+
+	t.Run("returns error when no database directory", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+
+		err := storage.InitDB(context.Background())
+		if err == nil {
+			t.Error("expected error when database directory is missing")
+		}
+	})
+}
+
+func TestCreateUserTable(t *testing.T) {
+	t.Run("creates table and allows insert", func(t *testing.T) {
+		dbPath := filepath.Join(t.TempDir(), "test.db")
+
+		db, err := sql.Open("sqlite3", dbPath)
+		if err != nil {
+			t.Fatalf("failed to open db: %v", err)
+		}
+		defer db.Close()
+
+		err = storage.CreateUserTable(context.Background(), db)
+		if err != nil {
+			t.Fatalf("CreateUserTable failed: %v", err)
+		}
+
+		_, err = db.ExecContext(
+			context.Background(),
+			"INSERT INTO users (first_name, last_name, email, password) VALUES (?, ?, ?, ?)",
+			"Test", "User", "test@example.com", "hash",
+		)
+		if err != nil {
+			t.Fatalf("insert into users failed: %v", err)
+		}
+	})
+}
+
 func getYAMLDocument() *fstest.MapFile {
 	return &fstest.MapFile{
 		Data: []byte(

--- a/internal/utils/scripts/auth_test.go
+++ b/internal/utils/scripts/auth_test.go
@@ -1,0 +1,73 @@
+package scripts_test
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"timterests/internal/utils/scripts"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestCreateUser(t *testing.T) {
+	t.Run("creates user in database", func(t *testing.T) {
+		dbDir := filepath.Join(t.TempDir(), "database")
+
+		err := os.MkdirAll(dbDir, 0750)
+		if err != nil {
+			t.Fatalf("failed to create database dir: %v", err)
+		}
+
+		t.Chdir(filepath.Dir(dbDir))
+
+		err = scripts.CreateUser("Jane", "Doe", "jane@example.com", "SecurePass123!")
+		if err != nil {
+			t.Fatalf("CreateUser failed: %v", err)
+		}
+
+		db, err := sql.Open("sqlite3", filepath.Join(dbDir, "timterests.db"))
+		if err != nil {
+			t.Fatalf("failed to open db: %v", err)
+		}
+		defer db.Close()
+
+		var email string
+
+		err = db.QueryRowContext(
+			context.Background(),
+			"SELECT email FROM users WHERE email = ?",
+			"jane@example.com",
+		).Scan(&email)
+		if err != nil {
+			t.Fatalf("failed to query user: %v", err)
+		}
+
+		if email != "jane@example.com" {
+			t.Errorf("expected email jane@example.com, got %q", email)
+		}
+	})
+
+	t.Run("returns error for duplicate email", func(t *testing.T) {
+		dbDir := filepath.Join(t.TempDir(), "database")
+
+		err := os.MkdirAll(dbDir, 0750)
+		if err != nil {
+			t.Fatalf("failed to create database dir: %v", err)
+		}
+
+		t.Chdir(filepath.Dir(dbDir))
+
+		err = scripts.CreateUser("First", "User", "dup@example.com", "Pass123!")
+		if err != nil {
+			t.Fatalf("first CreateUser failed: %v", err)
+		}
+
+		err = scripts.CreateUser("Second", "User", "dup@example.com", "Pass456!")
+		if err == nil {
+			t.Error("expected error for duplicate email")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
Coverage blitz PR #1 targeting zero-coverage and low-coverage packages.

- **`cmd/web/components`** (0% → 73.1%): Render tests for all templ components — Card variants (LargeCard, MiniCard, LinkCard), CardTitleContainer, FilterTags, FilterDesign, DownloadDocumentButton, DownloadNewDocumentButton
- **`internal/utils/scripts`** (0% → 88.9%): Integration test for CreateUser with real SQLite, including duplicate email rejection
- **`internal/auth`** (42.9% → 82.9%): DB-backed CreateUser and Authenticate tests — correct credentials, wrong password, nonexistent email, empty password, duplicate email
- **`internal/server`** (47.5% → 48.9%): CORS preflight, maxBytes middleware, HelloWorld content type tests. All three middleware functions now at 100%
- **`internal/storage`**: InitDB and CreateUserTable integration tests with idempotency check
- **`cmd/web`** (63.7% → 64.7%): FormatDateForFilename, grid/links design variants, modified-date sort branches

## Test plan
- [x] `go test ./...` — all tests pass
- [x] `golangci-lint run` — zero issues
- [x] No production code changes, test-only additions