### PR TITLE
test: add render tests for templ components

### DIFF
--- a/cmd/web/components/card_test.go
+++ b/cmd/web/components/card_test.go
@@ -1,0 +1,202 @@
+package components_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"timterests/cmd/web/components"
+)
+
+func render(t *testing.T, c interface{ Render(ctx context.Context, w io.Writer) error }) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	err := c.Render(context.Background(), &buf)
+	if err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+
+	return buf.String()
+}
+
+func TestLargeCard(t *testing.T) {
+	t.Parallel()
+
+	t.Run("renders all fields", func(t *testing.T) {
+		t.Parallel()
+
+		c := components.Card{
+			Title:     "Test Title",
+			Subtitle:  "Test Sub",
+			Date:      "2026-01-15",
+			Preview:   "Some preview text.",
+			ImagePath: "/images/test.png",
+			Get:       "/article?id=1",
+			Tags:      []string{"go", "testing"},
+			Index:     2,
+		}
+
+		html := render(t, c.LargeCard())
+
+		for _, want := range []string{
+			"Test Title",
+			"Test Sub",
+			"2026-01-15",
+			"Some preview text.",
+			"/images/test.png",
+			"/article?id=1",
+			"go",
+			"testing",
+			"card-container",
+			"animation-delay: 0.2s",
+		} {
+			if !strings.Contains(html, want) {
+				t.Errorf("LargeCard missing %q", want)
+			}
+		}
+	})
+
+	t.Run("omits image when ImagePath is empty", func(t *testing.T) {
+		t.Parallel()
+
+		c := components.Card{Title: "No Image", Get: "/x"}
+		html := render(t, c.LargeCard())
+
+		if strings.Contains(html, "card-image") {
+			t.Error("expected no card-image when ImagePath is empty")
+		}
+	})
+
+	t.Run("omits date when empty", func(t *testing.T) {
+		t.Parallel()
+
+		c := components.Card{Title: "No Date", Get: "/x"}
+		html := render(t, c.LargeCard())
+
+		if strings.Contains(html, "card-date") {
+			t.Error("expected no card-date when Date is empty")
+		}
+	})
+}
+
+func TestMiniCard(t *testing.T) {
+	t.Parallel()
+
+	t.Run("renders title and tags", func(t *testing.T) {
+		t.Parallel()
+
+		c := components.Card{
+			Title: "Mini Title",
+			Get:   "/mini",
+			Tags:  []string{"rust"},
+			Index: 0,
+		}
+
+		html := render(t, c.MiniCard())
+
+		for _, want := range []string{
+			"Mini Title",
+			"mini-card-container",
+			"rust",
+			"animation-delay: 0.0s",
+		} {
+			if !strings.Contains(html, want) {
+				t.Errorf("MiniCard missing %q", want)
+			}
+		}
+	})
+
+	t.Run("renders image when present", func(t *testing.T) {
+		t.Parallel()
+
+		c := components.Card{Title: "With Img", Get: "/x", ImagePath: "/img/cover.jpg"}
+		html := render(t, c.MiniCard())
+
+		if !strings.Contains(html, "card-image") {
+			t.Error("expected card-image in MiniCard with ImagePath")
+		}
+	})
+}
+
+func TestLinkCard(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with date shows date dash title", func(t *testing.T) {
+		t.Parallel()
+
+		c := components.Card{Title: "Link Title", Date: "2026-03-01", Get: "/link"}
+		html := render(t, c.LinkCard())
+
+		if !strings.Contains(html, "2026-03-01") {
+			t.Error("expected date in LinkCard")
+		}
+
+		if !strings.Contains(html, "Link Title") {
+			t.Error("expected title in LinkCard")
+		}
+
+		if !strings.Contains(html, "link-item") {
+			t.Error("expected link-item class")
+		}
+	})
+
+	t.Run("without date shows only title", func(t *testing.T) {
+		t.Parallel()
+
+		c := components.Card{Title: "No Date Link", Get: "/link2"}
+		html := render(t, c.LinkCard())
+
+		if !strings.Contains(html, "No Date Link") {
+			t.Error("expected title")
+		}
+
+		if strings.Contains(html, " - ") {
+			t.Error("expected no dash separator without date")
+		}
+	})
+}
+
+func TestCardTitleContainer(t *testing.T) {
+	t.Parallel()
+
+	html := render(t, components.CardTitleContainer("Main Title", "Sub Title"))
+
+	for _, want := range []string{
+		"card-title-container",
+		"Main Title",
+		"Sub Title",
+		"card-title",
+		"card-subtitle",
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("CardTitleContainer missing %q", want)
+		}
+	}
+}
+
+func TestAnimationDelay(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		index int
+		want  string
+	}{
+		{0, "0.0s"},
+		{1, "0.1s"},
+		{5, "0.5s"},
+		{10, "1.0s"},
+	}
+
+	for _, tc := range tests {
+		c := components.Card{Title: "T", Get: "/x", Index: tc.index}
+		html := render(t, c.LargeCard())
+
+		if !strings.Contains(html, tc.want) {
+			t.Errorf("Index %d: expected delay %q in HTML", tc.index, tc.want)
+		}
+	}
+}

--- a/cmd/web/components/download_test.go
+++ b/cmd/web/components/download_test.go
@@ -1,0 +1,63 @@
+package components_test
+
+import (
+	"strings"
+	"testing"
+
+	"timterests/cmd/web/components"
+)
+
+func TestDownloadDocumentButton(t *testing.T) {
+	t.Parallel()
+
+	t.Run("renders button for admin", func(t *testing.T) {
+		t.Parallel()
+
+		html := render(t, components.DownloadDocumentButton("articles/doc.yaml", true))
+
+		for _, want := range []string{
+			`action="/download"`,
+			`name="key"`,
+			`value="articles/doc.yaml"`,
+			"Download",
+		} {
+			if !strings.Contains(html, want) {
+				t.Errorf("DownloadDocumentButton missing %q", want)
+			}
+		}
+	})
+
+	t.Run("renders nothing for non-admin", func(t *testing.T) {
+		t.Parallel()
+
+		html := render(t, components.DownloadDocumentButton("articles/doc.yaml", false))
+
+		if strings.Contains(html, "Download") {
+			t.Error("expected no content for non-admin")
+		}
+	})
+}
+
+func TestDownloadNewDocumentButton(t *testing.T) {
+	t.Parallel()
+
+	t.Run("renders button for admin", func(t *testing.T) {
+		t.Parallel()
+
+		html := render(t, components.DownloadNewDocumentButton(true))
+
+		if !strings.Contains(html, `formaction="/download/new"`) {
+			t.Error("expected formaction for download/new")
+		}
+	})
+
+	t.Run("renders nothing for non-admin", func(t *testing.T) {
+		t.Parallel()
+
+		html := render(t, components.DownloadNewDocumentButton(false))
+
+		if strings.Contains(html, "Download") {
+			t.Error("expected no content for non-admin")
+		}
+	})
+}

--- a/cmd/web/components/filter_test.go
+++ b/cmd/web/components/filter_test.go
@@ -1,0 +1,90 @@
+package components_test
+
+import (
+	"strings"
+	"testing"
+
+	"timterests/cmd/web/components"
+)
+
+func TestFilterTags(t *testing.T) {
+	t.Parallel()
+
+	t.Run("renders all tag options plus All", func(t *testing.T) {
+		t.Parallel()
+
+		html := render(t, components.FilterTags("/articles", []string{"go", "rust", "python"}))
+
+		for _, want := range []string{
+			"filter-select",
+			`value="all"`,
+			"All",
+			`value="go"`,
+			`value="rust"`,
+			`value="python"`,
+			`hx-get="/articles"`,
+			`name="tag"`,
+		} {
+			if !strings.Contains(html, want) {
+				t.Errorf("FilterTags missing %q", want)
+			}
+		}
+	})
+
+	t.Run("empty tags renders only All option", func(t *testing.T) {
+		t.Parallel()
+
+		html := render(t, components.FilterTags("/x", nil))
+
+		if !strings.Contains(html, "All") {
+			t.Error("expected All option")
+		}
+
+		if count := strings.Count(html, "<option"); count != 1 {
+			t.Errorf("expected 1 option element, got %d", count)
+		}
+	})
+}
+
+func TestFilterDesign(t *testing.T) {
+	t.Parallel()
+
+	t.Run("list design is active by default", func(t *testing.T) {
+		t.Parallel()
+
+		html := render(t, components.FilterDesign("/articles", "list"))
+
+		if !strings.Contains(html, "view-options") {
+			t.Error("expected view-options container")
+		}
+
+		buttons := strings.Count(html, "view-btn")
+		if buttons < 3 {
+			t.Errorf("expected at least 3 view-btn references, got %d", buttons)
+		}
+	})
+
+	t.Run("empty design defaults to list active", func(t *testing.T) {
+		t.Parallel()
+
+		html := render(t, components.FilterDesign("/articles", ""))
+
+		if !strings.Contains(html, `"design": "list"`) {
+			t.Error("expected list design hx-vals")
+		}
+
+		if !strings.Contains(html, `"design": "grid"`) {
+			t.Error("expected grid design hx-vals")
+		}
+	})
+
+	t.Run("grid design renders grid button active", func(t *testing.T) {
+		t.Parallel()
+
+		html := render(t, components.FilterDesign("/projects", "grid"))
+
+		if !strings.Contains(html, `hx-get="/projects"`) {
+			t.Error("expected hx-get for projects")
+		}
+	})
+}

--- a/cmd/web/components/filter_test.go
+++ b/cmd/web/components/filter_test.go
@@ -46,6 +46,24 @@ func TestFilterTags(t *testing.T) {
 	})
 }
 
+// activeDesign returns which design button has the "active" class by splitting
+// the rendered HTML on "<button" boundaries and checking each section.
+func activeDesign(html string) string {
+	for section := range strings.SplitSeq(html, "<button") {
+		if !strings.Contains(section, "active") {
+			continue
+		}
+
+		for _, design := range []string{"list", "grid", "links"} {
+			if strings.Contains(section, `"design": "`+design+`"`) {
+				return design
+			}
+		}
+	}
+
+	return ""
+}
+
 func TestFilterDesign(t *testing.T) {
 	t.Parallel()
 
@@ -62,6 +80,10 @@ func TestFilterDesign(t *testing.T) {
 		if buttons < 3 {
 			t.Errorf("expected at least 3 view-btn references, got %d", buttons)
 		}
+
+		if got := activeDesign(html); got != "list" {
+			t.Errorf("expected list button to be active, got %q", got)
+		}
 	})
 
 	t.Run("empty design defaults to list active", func(t *testing.T) {
@@ -76,6 +98,10 @@ func TestFilterDesign(t *testing.T) {
 		if !strings.Contains(html, `"design": "grid"`) {
 			t.Error("expected grid design hx-vals")
 		}
+
+		if got := activeDesign(html); got != "list" {
+			t.Errorf("expected list button to be active for empty design, got %q", got)
+		}
 	})
 
 	t.Run("grid design renders grid button active", func(t *testing.T) {
@@ -85,6 +111,24 @@ func TestFilterDesign(t *testing.T) {
 
 		if !strings.Contains(html, `hx-get="/projects"`) {
 			t.Error("expected hx-get for projects")
+		}
+
+		if got := activeDesign(html); got != "grid" {
+			t.Errorf("expected grid button to be active, got %q", got)
+		}
+	})
+
+	t.Run("links design renders links button active", func(t *testing.T) {
+		t.Parallel()
+
+		html := render(t, components.FilterDesign("/reading-list", "links"))
+
+		if !strings.Contains(html, `hx-get="/reading-list"`) {
+			t.Error("expected hx-get for reading-list")
+		}
+
+		if got := activeDesign(html); got != "links" {
+			t.Errorf("expected links button to be active, got %q", got)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Render tests for all templ components: Card variants (LargeCard, MiniCard, LinkCard), CardTitleContainer, FilterTags, FilterDesign, DownloadDocumentButton, DownloadNewDocumentButton
- Covers `cmd/web/components` package (0% → ~73%)

Split from #180 for size compliance (~355 lines).

## Test plan
- [x] `go test ./cmd/web/components/ -v` — all pass
- [x] `golangci-lint run` — zero issues
- [x] No production code changes