### PR TITLE
test: add auth, server middleware, and scripts coverage

### DIFF
--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -2,11 +2,18 @@ package auth_test
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"timterests/internal/auth"
+	"timterests/internal/storage"
+
+	_ "github.com/mattn/go-sqlite3"
 )
 
 func newRequest() *http.Request {
@@ -150,6 +157,153 @@ func TestSetSessionValue(t *testing.T) {
 
 		if !a.IsAuthenticated(r2) {
 			t.Error("expected authenticated after setting email")
+		}
+	})
+}
+
+func setupAuthDB(t *testing.T) {
+	t.Helper()
+
+	dbDir := filepath.Join(t.TempDir(), "database")
+
+	err := os.MkdirAll(dbDir, 0750)
+	if err != nil {
+		t.Fatalf("failed to create database dir: %v", err)
+	}
+
+	dbPath := filepath.Join(dbDir, "timterests.db")
+
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	defer db.Close()
+
+	err = storage.CreateUserTable(context.Background(), db)
+	if err != nil {
+		t.Fatalf("failed to create users table: %v", err)
+	}
+
+	t.Chdir(filepath.Dir(dbDir))
+}
+
+func TestCreateUser(t *testing.T) {
+	t.Run("creates user successfully", func(t *testing.T) {
+		setupAuthDB(t)
+
+		a := auth.NewAuth("test-session")
+		ctx := context.Background()
+
+		err := a.CreateUser(ctx, "John", "Doe", "john@example.com", "Pass123!")
+		if err != nil {
+			t.Fatalf("CreateUser failed: %v", err)
+		}
+	})
+
+	t.Run("rejects duplicate email", func(t *testing.T) {
+		setupAuthDB(t)
+
+		a := auth.NewAuth("test-session")
+		ctx := context.Background()
+
+		err := a.CreateUser(ctx, "A", "B", "dup@test.com", "Pass123!")
+		if err != nil {
+			t.Fatalf("first CreateUser failed: %v", err)
+		}
+
+		err = a.CreateUser(ctx, "C", "D", "dup@test.com", "Pass456!")
+		if err == nil {
+			t.Error("expected error for duplicate email")
+		}
+	})
+
+	t.Run("rejects empty password", func(t *testing.T) {
+		setupAuthDB(t)
+
+		a := auth.NewAuth("test-session")
+
+		err := a.CreateUser(context.Background(), "X", "Y", "x@test.com", "")
+		if err == nil {
+			t.Error("expected error for empty password")
+		}
+	})
+}
+
+func TestAuthenticate(t *testing.T) {
+	t.Run("succeeds with correct credentials", func(t *testing.T) {
+		setupAuthDB(t)
+
+		a := auth.NewAuth("test-session")
+		ctx := context.Background()
+
+		err := a.CreateUser(ctx, "Auth", "User", "auth@test.com", "Correct123!")
+		if err != nil {
+			t.Fatalf("CreateUser failed: %v", err)
+		}
+
+		w := httptest.NewRecorder()
+		r := newRequest()
+
+		ok, err := a.Authenticate(ctx, w, r, "auth@test.com", "Correct123!")
+		if err != nil {
+			t.Fatalf("Authenticate failed: %v", err)
+		}
+
+		if !ok {
+			t.Error("expected authentication to succeed")
+		}
+
+		r2 := newRequest()
+		for _, c := range w.Result().Cookies() {
+			r2.AddCookie(c)
+		}
+
+		if !a.IsAuthenticated(r2) {
+			t.Error("expected session to be set after authentication")
+		}
+	})
+
+	t.Run("fails with wrong password", func(t *testing.T) {
+		setupAuthDB(t)
+
+		a := auth.NewAuth("test-session")
+		ctx := context.Background()
+
+		err := a.CreateUser(ctx, "Auth", "User", "wrong@test.com", "Correct123!")
+		if err != nil {
+			t.Fatalf("CreateUser failed: %v", err)
+		}
+
+		w := httptest.NewRecorder()
+		r := newRequest()
+
+		ok, err := a.Authenticate(ctx, w, r, "wrong@test.com", "WrongPass!")
+		if ok {
+			t.Error("expected authentication to fail")
+		}
+
+		if !errors.Is(err, auth.ErrInvalidCredentials) {
+			t.Errorf("expected ErrInvalidCredentials, got %v", err)
+		}
+	})
+
+	t.Run("fails with nonexistent email", func(t *testing.T) {
+		setupAuthDB(t)
+
+		a := auth.NewAuth("test-session")
+
+		w := httptest.NewRecorder()
+		r := newRequest()
+
+		ok, err := a.Authenticate(
+			context.Background(), w, r, "nobody@test.com", "Pass123!",
+		)
+		if ok {
+			t.Error("expected authentication to fail")
+		}
+
+		if !errors.Is(err, auth.ErrInvalidCredentials) {
+			t.Errorf("expected ErrInvalidCredentials, got %v", err)
 		}
 	})
 }

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -1,0 +1,7 @@
+package server
+
+import "net/http"
+
+func (s *Server) MaxBytesMiddleware(next http.Handler) http.Handler {
+	return s.maxBytesMiddleware(next)
+}

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -1,0 +1,39 @@
+package server_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"timterests/internal/server"
+)
+
+func TestMaxBytesMiddlewareRejectsOversizedBody(t *testing.T) {
+	s := &server.Server{}
+
+	drainBody := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
+
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := s.MaxBytesMiddleware(drainBody)
+
+	oversized := strings.NewReader(strings.Repeat("x", 11*1024*1024))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", oversized)
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusOK {
+		t.Error("expected rejection for oversized body, but got 200")
+	}
+}

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -9,6 +9,8 @@ import (
 
 	"timterests/internal/server"
 	"timterests/internal/storage"
+
+	_ "github.com/mattn/go-sqlite3"
 )
 
 func TestRoutes(t *testing.T) {
@@ -98,5 +100,174 @@ func TestSecurityHeaders(t *testing.T) {
 	pp := resp.Header.Get("Permissions-Policy")
 	if !strings.Contains(pp, "camera=()") {
 		t.Errorf("Permissions-Policy missing camera=(), got %q", pp)
+	}
+}
+
+func TestCORSPreflight(t *testing.T) {
+	setupHealthTestDB(t)
+
+	s := &server.Server{
+		Storage: &storage.Storage{
+			UseS3:   false,
+			BaseDir: t.TempDir(),
+		},
+	}
+
+	svr := httptest.NewServer(s.RegisterRoutes())
+	defer svr.Close()
+
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodOptions, svr.URL+"/health", nil,
+	)
+	if err != nil {
+		t.Fatalf("error creating request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("expected 204 for OPTIONS preflight, got %d", resp.StatusCode)
+	}
+
+	corsHeaders := map[string]string{
+		"Access-Control-Allow-Origin":  "*",
+		"Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS, PATCH",
+	}
+
+	for name, want := range corsHeaders {
+		got := resp.Header.Get(name)
+		if got != want {
+			t.Errorf("header %s: got %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestHelloWorldContentType(t *testing.T) {
+	t.Parallel()
+
+	s := &server.Server{}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(
+		t.Context(), http.MethodGet, "/hello", nil,
+	)
+
+	s.HelloWorldHandler(rec, req)
+
+	ct := rec.Header().Get("Content-Type")
+	if !strings.Contains(ct, "application/json") {
+		t.Errorf("expected JSON content type, got %q", ct)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "Hello World") {
+		t.Errorf("expected Hello World in body, got %q", body)
+	}
+}
+
+func TestRegisterRoutesEndpoints(t *testing.T) {
+	s := &server.Server{
+		Storage: &storage.Storage{
+			UseS3:   false,
+			BaseDir: t.TempDir(),
+		},
+	}
+
+	svr := httptest.NewServer(s.RegisterRoutes())
+	defer svr.Close()
+
+	endpoints := []string{
+		"/",
+		"/home",
+		"/web",
+		"/web/home",
+		"/articles",
+		"/projects",
+		"/reading-list",
+		"/login",
+		"/sitemap.xml",
+		"/about",
+		"/writer",
+		"/writer?type-id=invalid",
+		"/admin",
+		"/admin/documents",
+		"/admin/users",
+		"/admin/users/create",
+		"/write",
+		"/write/suggest",
+		"/download",
+		"/download/new",
+		"/article",
+		"/project",
+		"/book",
+		"/letter",
+		"/letters",
+	}
+
+	for _, path := range endpoints {
+		t.Run(path, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svr.URL+path, nil)
+			if err != nil {
+				t.Fatalf("error creating request: %v", err)
+			}
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("error making request to %s: %v", path, err)
+			}
+
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode == 0 {
+				t.Errorf("expected non-zero status code for %s", path)
+			}
+		})
+	}
+}
+
+func TestRecoveryMiddlewarePanic(t *testing.T) {
+	s := &server.Server{
+		Storage: &storage.Storage{
+			UseS3:   false,
+			BaseDir: t.TempDir(),
+		},
+		// auth is nil — /letters calls a.IsAuthenticated → nil deref → panic
+	}
+
+	svr := httptest.NewServer(s.RegisterRoutes())
+	defer svr.Close()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svr.URL+"/letters", nil)
+	if err != nil {
+		t.Fatalf("error creating request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("error making request: %v", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected 500 from panic recovery, got %d", resp.StatusCode)
+	}
+}
+
+func TestNewServer(t *testing.T) {
+	t.Setenv("PORT", "18080")
+	t.Setenv("SESSION_NAME", "test-session")
+
+	svr := server.NewServer()
+	if svr == nil {
+		t.Fatal("expected non-nil server")
+	}
+
+	if svr.Addr != ":18080" {
+		t.Errorf("expected addr :18080, got %s", svr.Addr)
 	}
 }

--- a/internal/utils/scripts/auth_test.go
+++ b/internal/utils/scripts/auth_test.go
@@ -1,0 +1,73 @@
+package scripts_test
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"timterests/internal/utils/scripts"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestCreateUser(t *testing.T) {
+	t.Run("creates user in database", func(t *testing.T) {
+		dbDir := filepath.Join(t.TempDir(), "database")
+
+		err := os.MkdirAll(dbDir, 0750)
+		if err != nil {
+			t.Fatalf("failed to create database dir: %v", err)
+		}
+
+		t.Chdir(filepath.Dir(dbDir))
+
+		err = scripts.CreateUser("Jane", "Doe", "jane@example.com", "SecurePass123!")
+		if err != nil {
+			t.Fatalf("CreateUser failed: %v", err)
+		}
+
+		db, err := sql.Open("sqlite3", filepath.Join(dbDir, "timterests.db"))
+		if err != nil {
+			t.Fatalf("failed to open db: %v", err)
+		}
+		defer db.Close()
+
+		var email string
+
+		err = db.QueryRowContext(
+			context.Background(),
+			"SELECT email FROM users WHERE email = ?",
+			"jane@example.com",
+		).Scan(&email)
+		if err != nil {
+			t.Fatalf("failed to query user: %v", err)
+		}
+
+		if email != "jane@example.com" {
+			t.Errorf("expected email jane@example.com, got %q", email)
+		}
+	})
+
+	t.Run("returns error for duplicate email", func(t *testing.T) {
+		dbDir := filepath.Join(t.TempDir(), "database")
+
+		err := os.MkdirAll(dbDir, 0750)
+		if err != nil {
+			t.Fatalf("failed to create database dir: %v", err)
+		}
+
+		t.Chdir(filepath.Dir(dbDir))
+
+		err = scripts.CreateUser("First", "User", "dup@example.com", "Pass123!")
+		if err != nil {
+			t.Fatalf("first CreateUser failed: %v", err)
+		}
+
+		err = scripts.CreateUser("Second", "User", "dup@example.com", "Pass456!")
+		if err == nil {
+			t.Error("expected error for duplicate email")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- **internal/auth**: DB-backed CreateUser and Authenticate tests — correct credentials, wrong password, nonexistent email, empty password, duplicate email rejection, session env fallback
- **internal/server**: CORS preflight, HelloWorld content type, endpoint registration smoke test, recovery middleware panic test, NewServer, maxBytes middleware via export_test.go bridge
- **internal/utils/scripts**: CreateUser integration test with duplicate email guard

Split from #180 for size compliance (~444 lines).

## Test plan
- [x] `go test ./internal/auth/ ./internal/server/ ./internal/utils/scripts/ -v` — all pass
- [x] `golangci-lint run` — zero issues
- [x] No production code changes