### PR TITLE
feat: add HIDDEN_PAGES env var to toggle page visibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,10 @@ SITE_URL=http://localhost:8080
 # FontAwesome kit ID (omit to disable icons)
 # FONTAWESOME_KIT_ID=your-kit-id
 
+# Hidden pages: comma-separated list of pages to disable (removes from nav, returns 404)
+# Valid values: articles, projects, reading-list
+# HIDDEN_PAGES=articles,projects,reading-list
+
 # Analytics (omit to disable)
 # GOATCOUNTER_URL=your-site.goatcounter.com
 

--- a/cmd/web/base.templ
+++ b/cmd/web/base.templ
@@ -192,9 +192,15 @@ templ Base(activePage string, metas ...MetaProps) {
 				<label for="nav-toggle" class="nav-toggle-label" aria-hidden="true"><i class="fa-solid fa-bars"></i></label>
 				<div class="nav-links">
 					<a href="/home" class={ "nav-link", templ.KV("active", activePage == "home") }><i class="fa-solid fa-house" aria-hidden="true"></i> Home</a>
-					<a href="/articles" class={ "nav-link", templ.KV("active", activePage == "articles") }><i class="fa-solid fa-newspaper" aria-hidden="true"></i> Articles</a>
-					<a href="/projects" class={ "nav-link", templ.KV("active", activePage == "projects") }><i class="fa-brands fa-github" aria-hidden="true"></i> Projects</a>
-					<a href="/reading-list" class={ "nav-link", templ.KV("active", activePage == "reading-list") }><i class="fa-solid fa-book" aria-hidden="true"></i> Reading List</a>
+					if !Site().IsHidden("articles") {
+						<a href="/articles" class={ "nav-link", templ.KV("active", activePage == "articles") }><i class="fa-solid fa-newspaper" aria-hidden="true"></i> Articles</a>
+					}
+					if !Site().IsHidden("projects") {
+						<a href="/projects" class={ "nav-link", templ.KV("active", activePage == "projects") }><i class="fa-brands fa-github" aria-hidden="true"></i> Projects</a>
+					}
+					if !Site().IsHidden("reading-list") {
+						<a href="/reading-list" class={ "nav-link", templ.KV("active", activePage == "reading-list") }><i class="fa-solid fa-book" aria-hidden="true"></i> Reading List</a>
+					}
 					<a href="/about" class={ "nav-link", templ.KV("active", activePage == "about") }><i class="fa-solid fa-question" aria-hidden="true"></i> About</a>
 				</div>
 			</nav>
@@ -204,9 +210,15 @@ templ Base(activePage string, metas ...MetaProps) {
 			<footer class="banner-footer">
 				<nav class="footer-nav" aria-label="Footer navigation">
 					<a href="/home" class="nav-footer-link">Home</a>
-					<a href="/articles" class="nav-footer-link">Articles</a>
-					<a href="/projects" class="nav-footer-link">Projects</a>
-					<a href="/reading-list" class="nav-footer-link">Reading List</a>
+					if !Site().IsHidden("articles") {
+						<a href="/articles" class="nav-footer-link">Articles</a>
+					}
+					if !Site().IsHidden("projects") {
+						<a href="/projects" class="nav-footer-link">Projects</a>
+					}
+					if !Site().IsHidden("reading-list") {
+						<a href="/reading-list" class="nav-footer-link">Reading List</a>
+					}
 					<a href="/about" class="nav-footer-link">About</a>
 				</nav>
 				<p class="copywrite-text">

--- a/cmd/web/config.go
+++ b/cmd/web/config.go
@@ -1,6 +1,9 @@
 package web
 
-import "os"
+import (
+	"os"
+	"strings"
+)
 
 // SiteConfig holds site identity values read from environment variables.
 // Defaults match the original hardcoded Timterests values.
@@ -12,10 +15,28 @@ type SiteConfig struct {
 	Description    string // SITE_DESCRIPTION
 	RepoURL        string // REPO_URL
 	FontAwesomeKit string // FONTAWESOME_KIT_ID
+	hiddenPages    map[string]struct{}
+}
+
+// IsHidden reports whether a named page (e.g. "articles", "projects", "reading-list")
+// has been disabled via the HIDDEN_PAGES environment variable.
+func (s SiteConfig) IsHidden(page string) bool {
+	_, ok := s.hiddenPages[page]
+	return ok
 }
 
 // Site returns the current site configuration from environment variables.
 func Site() SiteConfig {
+	hidden := make(map[string]struct{})
+
+	if v := os.Getenv("HIDDEN_PAGES"); v != "" {
+		for _, p := range strings.Split(v, ",") {
+			if p = strings.TrimSpace(p); p != "" {
+				hidden[p] = struct{}{}
+			}
+		}
+	}
+
 	return SiteConfig{
 		Name:           envOr("SITE_NAME", "Timterests"),
 		Subtitle:       envOr("SITE_SUBTITLE", "Tim's interests"),
@@ -25,6 +46,7 @@ func Site() SiteConfig {
 			"Tim Scott's personal site — articles, projects, and a curated reading list."),
 		RepoURL:        envOr("REPO_URL", "https://github.com/TheTimbob/timterests"),
 		FontAwesomeKit: envOr("FONTAWESOME_KIT_ID", "3453ab8a44"),
+		hiddenPages:    hidden,
 	}
 }
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -130,31 +130,55 @@ func (s *Server) RegisterRoutes() http.Handler {
 
 	// Article Routes
 	mux.Handle("/articles", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if web.Site().IsHidden("articles") {
+			http.NotFound(w, r)
+			return
+		}
 		design := r.URL.Query().Get("design")
 		tag := r.URL.Query().Get("tag")
 		web.ArticlesPageHandler(w, r, *s.Storage, tag, design)
 	}))
 	mux.Handle("/article", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if web.Site().IsHidden("articles") {
+			http.NotFound(w, r)
+			return
+		}
 		articleID := r.URL.Query().Get("id")
 		web.GetArticleHandler(w, r, *s.Storage, articleID, s.auth)
 	}))
 	// Projects Routes
 	mux.Handle("/projects", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if web.Site().IsHidden("projects") {
+			http.NotFound(w, r)
+			return
+		}
 		design := r.URL.Query().Get("design")
 		tag := r.URL.Query().Get("tag")
 		web.ProjectsPageHandler(w, r, *s.Storage, tag, design)
 	}))
 	mux.Handle("/project", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if web.Site().IsHidden("projects") {
+			http.NotFound(w, r)
+			return
+		}
 		projectID := r.URL.Query().Get("id")
 		web.GetProjectHandler(w, r, *s.Storage, projectID, s.auth)
 	}))
 	// Reading List Routes
 	mux.Handle("/reading-list", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if web.Site().IsHidden("reading-list") {
+			http.NotFound(w, r)
+			return
+		}
 		design := r.URL.Query().Get("design")
 		tag := r.URL.Query().Get("tag")
 		web.ReadingListPageHandler(w, r, *s.Storage, tag, design)
 	}))
 	mux.Handle("/book", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if web.Site().IsHidden("reading-list") {
+			http.NotFound(w, r)
+			return
+		}
 		articleID := r.URL.Query().Get("id")
 		web.GetReadingListBook(w, r, *s.Storage, articleID, s.auth)
 	}))


### PR DESCRIPTION
## Summary
- Adds `HIDDEN_PAGES` env var — a comma-separated list of page slugs to disable (e.g. `HIDDEN_PAGES=articles,projects,reading-list`)
- Hidden pages are removed from the nav header and footer
- Direct URL access to hidden pages returns 404
- Re-enabling is just an env change — no redeploy of code needed

## Test plan
- [ ] Set `HIDDEN_PAGES=articles` in `.env`, run app — Articles disappears from nav/footer, `/articles` and `/article?id=...` return 404
- [ ] Clear `HIDDEN_PAGES` — Articles reappears with no other changes
- [ ] Set multiple values (`articles,projects`) — both hidden simultaneously